### PR TITLE
fix(auth): enforce JWT secret in production and document local fallback

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,7 @@
 PORT=3000
 DATABASE_URL="postgresql://user:password@host:5432/dbname?schema=ticketing"
 SOROBAN_RPC_URL="https://soroban-testnet.stellar.org"
+# Obligatorio en producción. En desarrollo local, si falta, el servidor usa un fallback inseguro con warning.
 JWT_SECRET="change-this-to-a-random-secret-in-production"
 
 # Opcional: operaciones on-chain desde el backend (ver backend/README.md)

--- a/backend/README.md
+++ b/backend/README.md
@@ -85,13 +85,13 @@ Si la indexación continua se ejecuta por separado en tu despliegue, debe apunta
 |---------------------|------------|-------------|
 | `DATABASE_URL`      | Sí         | URL de PostgreSQL (incluye `?schema=ticketing` si aplica). |
 | `PORT`              | No         | Puerto HTTP (por defecto `3000`). |
-| `JWT_SECRET`        | No*        | Firma de tokens JWT. En cualquier despliegue serio debe definirse explícitamente y ser fuerte. |
+| `JWT_SECRET`        | Sí en producción* | Firma de tokens JWT. Debe definirse explícitamente y ser fuerte en producción. |
 | `SOROBAN_RPC_URL`   | No         | RPC Soroban (por defecto testnet público). |
 | `ORGANIZER_SECRET`  | No**       | Secret key del organizador para operaciones que construyen/envían transacciones desde el backend. |
 | `ORGANIZER_PUBLIC`  | No         | Clave pública del organizador usada en rutas admin/contratos si no quieres el valor por defecto del código. |
 | `VERCEL`            | No         | En despliegues serverless la define el proveedor; si existe, `server.ts` no ejecuta el bloque de proceso largo (`listen` + `runIndexer()`). |
 
-\* En desarrollo puede existir un valor por defecto en el código, pero no debe usarse en entornos compartidos, demos públicas o producción.
+\* En desarrollo local, si `JWT_SECRET` no está definido, el servidor permite un fallback inseguro y muestra un warning en consola. Ese fallback no debe usarse en entornos compartidos, demos públicas ni producción; con `NODE_ENV=production`, la aplicación falla al iniciar si falta `JWT_SECRET`.
 
 \*\* Sin `ORGANIZER_SECRET`, algunas rutas on-chain responderán con error de servicio no configurado.
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -30,7 +30,18 @@ dotenv.config();
 const app = express();
 const prisma = new PrismaClient();
 const PORT = process.env.PORT || 3000;
-const JWT_SECRET = process.env.JWT_SECRET || 'stellar-tickets-dev-secret-change-in-prod';
+const NODE_ENV = process.env.NODE_ENV || 'development';
+const isProduction = NODE_ENV === 'production';
+const configuredJwtSecret = process.env.JWT_SECRET;
+
+if (!configuredJwtSecret && isProduction) {
+  throw new Error('Missing required environment variable: JWT_SECRET');
+}
+
+const EFFECTIVE_JWT_SECRET = configuredJwtSecret || 'stellar-tickets-dev-secret-change-in-prod';
+if (!configuredJwtSecret) {
+  console.warn('[WARN] JWT_SECRET is not set. Using insecure development fallback; do not use this in shared, demo, or production environments.');
+}
 const JWT_EXPIRES_IN = '7d';
 
 // Soroban / Stellar config
@@ -65,7 +76,7 @@ function authMiddleware(req: Request, res: Response, next: NextFunction) {
     return;
   }
   try {
-    const payload = jwt.verify(header.slice(7), JWT_SECRET) as { userId: string };
+    const payload = jwt.verify(header.slice(7), EFFECTIVE_JWT_SECRET) as { userId: string };
     (req as any).userId = payload.userId;
     next();
   } catch {
@@ -930,7 +941,7 @@ app.post('/api/auth/login', async (req, res) => {
     // Update last login
     await prisma.users.update({ where: { id: user.id }, data: { last_login_at: new Date() } });
 
-    const accessToken = jwt.sign({ userId: user.id }, JWT_SECRET, { expiresIn: JWT_EXPIRES_IN });
+    const accessToken = jwt.sign({ userId: user.id }, EFFECTIVE_JWT_SECRET, { expiresIn: JWT_EXPIRES_IN });
     res.json({ accessToken, user: toUserDto(user) });
   } catch (error: any) {
     console.error('[AUTH] Login error:', error);
@@ -966,7 +977,7 @@ app.post('/api/auth/register', async (req, res) => {
       },
     });
 
-    const accessToken = jwt.sign({ userId: user.id }, JWT_SECRET, { expiresIn: JWT_EXPIRES_IN });
+    const accessToken = jwt.sign({ userId: user.id }, EFFECTIVE_JWT_SECRET, { expiresIn: JWT_EXPIRES_IN });
     res.json({ accessToken, user: toUserDto(user) });
   } catch (error: any) {
     console.error('[AUTH] Register error:', error);


### PR DESCRIPTION
## Qué se hizo
- Se endureció la configuración de `JWT_SECRET` en backend.
- Ahora en producción la variable es obligatoria.
- En desarrollo local se permite fallback inseguro con warning explícito.
- Se alineó `.env.example` y `backend/README.md` con el comportamiento real.

## Por qué
- El backend no debía arrancar silenciosamente con un secreto JWT predecible en despliegues serios.

## Cómo se probó
- `npm run build` en backend
- arranque en desarrollo sin `JWT_SECRET`: el servidor inicia con warning
- arranque en producción sin `JWT_SECRET`: el servidor falla con error claro
- arranque normal con `JWT_SECRET` restaurado

## Riesgos
- Entornos que antes arrancaban sin `JWT_SECRET` en producción ahora fallarán correctamente hasta configurarlo.