### PR TITLE
fix(cart): prevent cross-user cart item access

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1130,12 +1130,23 @@ app.post('/api/cart/items', authMiddleware, async (req, res) => {
 // PATCH /api/cart/items/:id — update quantity
 app.patch('/api/cart/items/:id', authMiddleware, async (req, res) => {
   try {
+    const userId = (req as any).userId;
     const { quantity } = req.body;
     if (!quantity || quantity < 1) {
       res.status(400).json({ error: 'quantity debe ser >= 1' });
       return;
     }
-    await prisma.cart_items.update({ where: { id: req.params.id as string }, data: { quantity } });
+    const result = await prisma.cart_items.updateMany({
+      where: {
+        id: req.params.id as string,
+        carts: { is: { user_id: userId, status: 'ACTIVE' } },
+      },
+      data: { quantity },
+    });
+    if (result.count === 0) {
+      res.status(404).json({ error: 'Item de carrito no encontrado' });
+      return;
+    }
     res.status(204).send();
   } catch (error: any) {
     console.error('[CART] PATCH error:', error);
@@ -1146,7 +1157,17 @@ app.patch('/api/cart/items/:id', authMiddleware, async (req, res) => {
 // DELETE /api/cart/items/:id — remove single item
 app.delete('/api/cart/items/:id', authMiddleware, async (req, res) => {
   try {
-    await prisma.cart_items.delete({ where: { id: req.params.id as string } });
+    const userId = (req as any).userId;
+    const result = await prisma.cart_items.deleteMany({
+      where: {
+        id: req.params.id as string,
+        carts: { is: { user_id: userId, status: 'ACTIVE' } },
+      },
+    });
+    if (result.count === 0) {
+      res.status(404).json({ error: 'Item de carrito no encontrado' });
+      return;
+    }
     res.status(204).send();
   } catch (error: any) {
     console.error('[CART] DELETE error:', error);


### PR DESCRIPTION
## Qué se hizo

- Se corrigió el riesgo de IDOR en los endpoints de carrito.
- `PATCH /api/cart/items/:id` ahora solo permite modificar items del carrito activo del usuario autenticado.
- `DELETE /api/cart/items/:id` ahora solo permite eliminar items del carrito activo del usuario autenticado.
- Si el item no existe o pertenece a otro usuario, la API responde `404`.

## Por qué

Antes, un usuario autenticado podía intentar modificar o eliminar un `cart_item` usando directamente su ID, sin validar que ese item perteneciera a su propio carrito.

Esto podía permitir acceso cruzado entre usuarios si alguien obtenía o adivinaba un ID válido.

## Cómo se probó

- Se levantó el backend localmente.
- Se crearon dos usuarios de prueba.
- Usuario A creó un item en su carrito.
- Usuario B intentó modificar el item de Usuario A:
  - resultado esperado: `404`
- Usuario B intentó eliminar el item de Usuario A:
  - resultado esperado: `404`
- Se verificó que el carrito de Usuario A no cambió.
- Usuario A sí pudo modificar su propio item:
  - resultado esperado: `204`
- Usuario A sí pudo eliminar su propio item:
  - resultado esperado: `204`

También se ejecutó:

```bash
cd backend
npx tsc --noEmit
```

## Riesgos
- Bajo.
- El cambio está limitado a los endpoints de modificación y eliminación de items del carrito.
- La respuesta para items ajenos es 404 para no revelar existencia de recursos de otros usuarios.