### PR TITLE
fix(transactions): validate submit wallet context

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -8,6 +8,7 @@ import {
   Keypair,
   Networks,
   TransactionBuilder,
+  FeeBumpTransaction,
   Operation,
   Account,
   Address,
@@ -635,9 +636,20 @@ app.post('/api/transactions/cancel-listing', authMiddleware, async (req, res) =>
 // POST /api/transactions/build-buy-xdr — Build unsigned XDR for comprar_boleto (Freighter signs)
 app.post('/api/transactions/build-buy-xdr', authMiddleware, async (req, res) => {
   try {
+    const userId = (req as any).userId;
     const { contractAddress, ticketRootId, buyerPublicKey } = req.body;
     if (!contractAddress || ticketRootId === undefined || !buyerPublicKey) {
       res.status(400).json({ error: 'contractAddress, ticketRootId y buyerPublicKey son requeridos' });
+      return;
+    }
+
+    const user = await prisma.users.findUnique({ where: { id: userId }, select: { wallet_address: true } });
+    if (!user?.wallet_address) {
+      res.status(400).json({ error: 'Debes vincular una wallet antes de construir una transacción' });
+      return;
+    }
+    if (buyerPublicKey !== user.wallet_address) {
+      res.status(403).json({ error: 'buyerPublicKey no coincide con la wallet vinculada al usuario' });
       return;
     }
 
@@ -703,13 +715,28 @@ app.post('/api/transactions/build-buy-xdr', authMiddleware, async (req, res) => 
 // POST /api/transactions/submit — Submit Freighter-signed XDR to Soroban
 app.post('/api/transactions/submit', authMiddleware, async (req, res) => {
   try {
+    const userId = (req as any).userId;
     const { signedXdr } = req.body;
     if (!signedXdr) {
       res.status(400).json({ error: 'signedXdr es requerido' });
       return;
     }
 
+    const user = await prisma.users.findUnique({ where: { id: userId }, select: { wallet_address: true } });
+    if (!user?.wallet_address) {
+      res.status(400).json({ error: 'Debes vincular una wallet antes de enviar una transacción' });
+      return;
+    }
+
     const tx = TransactionBuilder.fromXDR(signedXdr, NETWORK_PASSPHRASE);
+    if (tx instanceof FeeBumpTransaction) {
+      res.status(400).json({ error: 'Las transacciones fee-bump no están soportadas en este endpoint' });
+      return;
+    }
+    if (tx.source !== user.wallet_address) {
+      res.status(403).json({ error: 'La transacción firmada no corresponde a la wallet vinculada al usuario' });
+      return;
+    }
 
     const sendResponse = await sorobanServer.sendTransaction(tx);
     if (sendResponse.status === 'ERROR') {


### PR DESCRIPTION
## Qué se hizo
- Se agregó validación de wallet vinculada antes de construir XDRs de compra.
- Se bloquea `build-buy-xdr` cuando `buyerPublicKey` no coincide con la wallet del usuario autenticado.
- Se agregó validación de wallet vinculada antes de enviar XDRs firmados.
- Se bloquea `submit` cuando el `source` del XDR firmado no coincide con la wallet vinculada.
- Se rechazan transacciones `fee-bump` en `/api/transactions/submit`.

## Por qué
- El endpoint `/api/transactions/submit` aceptaba XDRs firmados sin validar que pertenecieran al usuario autenticado.
- Esto permitía enviar transacciones sin relación clara entre sesión, wallet y operación.
- El cambio reduce el riesgo de aceptar XDRs arbitrarios y alinea el backend con el contexto de wallet del usuario.

## Cómo se probó
- Se ejecutó:
  ```bash
  cd backend
  npx tsc --noEmit
  ```
- Se probó por API:
- usuario sin wallet no puede construir XDR de compra: 400
- usuario sin wallet no puede enviar XDR firmado: 400
- usuario con wallet no puede construir XDR usando otro buyerPublicKey: 403
- usuario con wallet no puede enviar XDR cuyo source es otra wallet: 403
- Se verificó /health del backend local.
## Riesgos
- El endpoint ahora rechaza transacciones fee-bump; si en el futuro se necesita soportarlas, habrá que validar también la transacción interna.
- Usuarios sin wallet vinculada ya no podrán usar el flujo de compra on-chain hasta vincular una wallet.

## Checklist
- [X] compiló correctamente
- [X] probé el flujo afectado
- [X] no subí secretos ni archivos temporales
- [] actualicé documentación si aplicaba