### PR TITLE
Feature/seat map api

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+> ⚠️ **PATHS — read first.** El código activo vive en `D:\Tesis\Codigo\main_contract\backend` y `D:\Tesis\Codigo\main_contract\frontend`. **NO** trabajes en `D:\Tesis\backend\` ni `D:\Tesis\frontend\` — son copias viejas/stale; cualquier edición ahí no afecta al backend que corre en `localhost:3000` ni al Vite dev server.
+
 ## Repository Layout
 
 This workspace contains one monorepo plus thesis documentation:
@@ -437,8 +439,24 @@ docs/
   - **User cleanup script**: `backend/scripts/clean-users.ts` resets users for demo recording.
   - **Render deploy fixes**: `stellar-sdk` pinned to `14.4.1`, start command uses `tsx src/server.ts` instead of compiled JS, `tsconfig.json` has `incremental: false`.
 
+- **Phase 4.1 (seated events + wallet rotation + UX polish)** — Implemented 2026-05-02:
+  - **Seat-based purchase flow restored**: Tras refactor previo dejó de funcionar `GET /api/events/:id/seats` (400 "Este evento no tiene selección de asientos"). Solucionado convirtiendo todos los eventos a asignación de asientos con `backend/scripts/seed-seat-inventory.ts` (idempotente): crea 3 secciones por venue (VIP 2×10, Platea 3×12, General 4×14), seats numerados, `event_seat_inventory` con status `AVAILABLE`, ticket_types atados a sección con `inventory_quantity = null`. Sets `events.has_assigned_seating = true`.
+  - **Cart trigger fix**: El trigger `validate_cart_item_consistency` rechazaba inserts seat-based porque exigía `inventory_quantity NOT NULL` para cualquier `event_ticket_type_id`. Solucionado en `backend/scripts/fix-cart-trigger.ts` agregando guard `AND NEW.event_seat_inventory_id IS NULL` (solo valida quantity-based para flujo GA).
+  - **set_updated_at restoration**: La función `ticketing.set_updated_at` se sobreescribió accidentalmente con la lógica del cart trigger, causando `column "new" does not exist` en cualquier UPDATE. Restaurada con `backend/scripts/restore-set-updated-at.ts` a su lógica trivial (`NEW.updated_at = NOW()`).
+  - **Cart/order/ticket DTOs con seat-based fallback**: `cart_items`, `order_items` y `tickets` para flujo seat-based solo guardan `event_seat_inventory_id` (NO `event_ticket_type_id`) por el CHECK constraint `chk_cart_items_one_source` / `chk_order_items_one_source`. Endpoints `GET /api/cart`, `GET /api/tickets`, `POST /api/transactions/secure-ticket`, `GET /api/tickets/sold` ahora resuelven el `ticketType` y `event` vía `event_seat_inventory.event_ticket_types.events` cuando el join directo es null.
+  - **Wallet rotation**: Las wallets demo del proyecto se rotaron a un set con 12 palabras documentadas en `.env.deploy` (ADMIN, ORGANIZER, PLATFORM, BUYER1, BUYER2, VERIFIER). El compañero las creó con nombres claros para trazabilidad de la tesis.
+  - **Contract recompile + redeploy**: El WASM en `contracts/wasm/event_contract.wasm` era del 31-mar (pre commit 9361285 "ownership inconsistency fix") y NO contenía la función `crear_boleto_para` que llama el backend. Recompilado con `cargo build --release --target wasm32v1-none` (target Soroban-compatible; `wasm32-unknown-unknown` genera reference-types que Soroban rechaza). 12 contratos redesplegados en testnet con WASM nuevo + nuevas wallets organizer/admin.
+  - **Deploy script refactor** (`backend/scripts/deploy-contracts.ts`):
+    - Ya NO genera keypairs aleatorios; carga ADMIN/PLATFORM/ORGANIZER desde `.env.deploy`.
+    - Salt aleatorio por contrato (evita colisión `ExistingValue` al redesplegar con mismo admin).
+    - WASM_DIR apunta a `contracts/wasm/` (carpeta versionada) en vez del `target/release` local.
+    - Antes del deploy, limpia `contract_address = null` en todos los eventos PUBLISHED para forzar redeploy.
+  - **UI: precio de reventa en COP**: `TicketCard.tsx` reemplaza `prompt()` nativo con un `<Dialog>` shadcn/ui. Usuario ingresa precio en COP, ve preview en vivo del equivalente en XLM (usando `useXlmPrice`) y la cotización actual. Backend sigue recibiendo XLM/stroops; la conversión es solo UI. Mejora UX para usuarios no-cripto.
+  - **ConnectWallet persistente entre navegaciones**: Cada página renderiza su propio `<Header />`, lo que remontaba `ConnectWallet` y mostraba "Connect Wallet" durante ~300-500ms al navegar. Refactorizado para leer `walletAddress` directamente del `AppContext` (persistente) en lugar de estado local. Solo invoca a Freighter cuando NO hay address en el context. Resultado: la wallet se mantiene visible al cambiar de pantalla y al recargar (gracias a que `/api/users/me` devuelve `walletAddress`).
+  - **Critical path note**: El código activo vive en `D:\Tesis\Codigo\main_contract\backend|frontend`. NO trabajar en `D:\Tesis\backend\` ni `D:\Tesis\frontend\` — son copias stale. Warning añadido al top de este CLAUDE.md.
+
 ### Pending — NEXT SESSION START HERE
-- **Phase 5** — Thesis documentation: **updated DB diagram** (new `resale_price` column, STAFF role), updated architecture diagrams, Web2 problem mitigation analysis, test evidence screenshots, latency/cost metrics (Stroops)
+- **Phase 5** — Thesis documentation: **updated DB diagram** (new `resale_price` column, STAFF role, seat inventory tables), updated architecture diagrams, Web2 problem mitigation analysis, test evidence screenshots, latency/cost metrics (Stroops)
 
 ### Key architectural rules
 - Backend signs `crear_boleto`, `listar_boleto`, and `cancelar_venta` server-side with organizer key. For buyer-facing operations (`comprar_boleto`), backend builds unsigned XDR and frontend signs with **Freighter wallet**

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,8 @@
 PORT=3000
-DATABASE_URL="postgresql://user:password@host:5432/dbname?schema=ticketing"
+# Para Supabase pooler en desarrollo/demo, evita connection_limit=1 porque la UI hace varias consultas.
+DATABASE_URL="postgresql://user:password@host:5432/dbname?pgbouncer=true&connection_limit=5&pool_timeout=30&sslmode=require"
 SOROBAN_RPC_URL="https://soroban-testnet.stellar.org"
+RUN_INDEXER=false
 # Obligatorio en producción. En desarrollo local, si falta, el servidor usa un fallback inseguro con warning.
 JWT_SECRET="change-this-to-a-random-secret-in-production"
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,9 @@
     "postinstall": "prisma generate",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
-    "prisma:deploy": "prisma migrate deploy"
+    "prisma:deploy": "prisma migrate deploy",
+    "env:test": "bash scripts/switch-env.sh test",
+    "env:prod": "bash scripts/switch-env.sh prod"
   },
   "dependencies": {
     "@prisma/client": "^6.9.0",

--- a/backend/scripts/deploy-contracts.ts
+++ b/backend/scripts/deploy-contracts.ts
@@ -32,7 +32,7 @@ dotenv.config();
 
 const RPC_URL = process.env.SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org';
 const NETWORK_PASSPHRASE = Networks.TESTNET;
-const WASM_DIR = path.resolve(__dirname, '../../contracts/target/wasm32-unknown-unknown/release');
+const WASM_DIR = path.resolve(__dirname, '../../contracts/wasm');
 
 const server = new SorobanRpc.Server(RPC_URL);
 const prisma = new PrismaClient();
@@ -177,44 +177,44 @@ async function initializeEventContract(
 async function main() {
   console.log('=== Soroban Contract Deployment to Testnet ===\n');
 
-  // 1. Load keys
-  const adminKeypair = Keypair.random();
-  const platformKeypair = Keypair.random();
-  const organizerKeypair = process.env.ORGANIZER_SECRET ? Keypair.fromSecret(process.env.ORGANIZER_SECRET) : Keypair.random();
+  // 1. Load keys from .env.deploy (pre-configured wallets)
+  const envDeployPath = path.resolve(__dirname, '../.env.deploy');
+  const envDeployContent = fs.readFileSync(envDeployPath, 'utf-8');
+  const envDeployVars: Record<string, string> = {};
+  for (const line of envDeployContent.split('\n')) {
+    const match = line.match(/^([A-Z0-9_]+)=(.+)$/);
+    if (match) envDeployVars[match[1]] = match[2].trim();
+  }
 
-  console.log('Keypairs:');
+  const adminKeypair = Keypair.fromSecret(envDeployVars['ADMIN_SECRET']);
+  const platformKeypair = Keypair.fromSecret(envDeployVars['PLATFORM_SECRET']);
+  const organizerKeypair = Keypair.fromSecret(envDeployVars['ORGANIZER_SECRET']);
+
+  console.log('Keypairs loaded from .env.deploy:');
   console.log(`  Admin:     ${adminKeypair.publicKey()}`);
   console.log(`  Platform:  ${platformKeypair.publicKey()}`);
   console.log(`  Organizer: ${organizerKeypair.publicKey()}`);
 
-  // Save keypairs to .env.deploy for reference
-  const envDeploy = `# Generated ${new Date().toISOString()}
-ADMIN_PUBLIC=${adminKeypair.publicKey()}
-ADMIN_SECRET=${adminKeypair.secret()}
-PLATFORM_PUBLIC=${platformKeypair.publicKey()}
-PLATFORM_SECRET=${platformKeypair.secret()}
-ORGANIZER_PUBLIC=${organizerKeypair.publicKey()}
-ORGANIZER_SECRET=${organizerKeypair.secret()}
-`;
-  fs.writeFileSync(path.resolve(__dirname, '../.env.deploy'), envDeploy);
-  console.log('\n  Keypairs saved to .env.deploy');
-
-  // 2. Fund accounts via Friendbot
+  // 2. Fund accounts via Friendbot (no-op if already funded)
   console.log('\nFunding accounts...');
   await fundAccount(adminKeypair.publicKey());
   await fundAccount(platformKeypair.publicKey());
   await fundAccount(organizerKeypair.publicKey());
 
   // 3. Upload event_contract WASM
-  const eventWasmPath = path.join(WASM_DIR, 'event_contract.optimized.wasm');
+  const eventWasmPath = path.join(WASM_DIR, 'event_contract.wasm');
   if (!fs.existsSync(eventWasmPath)) {
     throw new Error(`WASM not found: ${eventWasmPath}`);
   }
   const wasmHash = await uploadWasm(adminKeypair, eventWasmPath);
 
-  // 4. Get events from DB that need contracts
+  // 4. Clear existing contract addresses and redeploy all PUBLISHED events
+  await prisma.events.updateMany({
+    where: { status: 'PUBLISHED' },
+    data: { contract_address: null },
+  });
   const events = await prisma.events.findMany({
-    where: { status: 'PUBLISHED', contract_address: null },
+    where: { status: 'PUBLISHED' },
     orderBy: { created_at: 'asc' },
   });
 
@@ -225,9 +225,9 @@ ORGANIZER_SECRET=${organizerKeypair.secret()}
     const event = events[i];
     console.log(`\n--- [${i + 1}/${events.length}] ${event.title} ---`);
 
-    // Use event index as salt (unique per deploy)
-    const salt = Buffer.alloc(32, 0);
-    salt.writeUInt32BE(i + 1, 28);
+    // Use random salt so re-deploys (with new WASM) don't collide with existing addresses
+    const salt = Buffer.alloc(32);
+    for (let b = 0; b < 32; b++) salt[b] = Math.floor(Math.random() * 256);
 
     try {
       const contractAddress = await deployContract(adminKeypair, wasmHash, salt);

--- a/backend/scripts/fix-cart-trigger.ts
+++ b/backend/scripts/fix-cart-trigger.ts
@@ -1,0 +1,86 @@
+/**
+ * fix-cart-trigger.ts
+ *
+ * Repara el trigger BEFORE INSERT en `ticketing.cart_items`. El trigger original
+ * exige que `event_ticket_type_id.inventory_quantity` no sea NULL (es decir, que
+ * sea GA), pero esa restricción no aplica cuando se está agregando por asiento
+ * (event_seat_inventory_id NOT NULL).
+ *
+ * Solución: solo validar el inventory_quantity cuando NO hay seat_inventory_id
+ * (es decir, sólo cuando es flujo GA).
+ *
+ * Uso:
+ *   cd backend
+ *   node --import tsx scripts/fix-cart-trigger.ts
+ */
+
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+async function main() {
+  // Buscar la función que tiene el RAISE EXCEPTION específico
+  const fn = await prisma.$queryRawUnsafe<any[]>(`
+    SELECT p.proname AS name, n.nspname AS schema
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'ticketing'
+      AND prosrc LIKE '%cannot be added by quantity%';
+  `);
+  if (fn.length === 0) throw new Error('No encontré la función del trigger');
+  const { name: fnName, schema } = fn[0];
+  console.log(`Función a actualizar: ${schema}.${fnName}`);
+
+  // Replace function body con la versión corregida
+  await prisma.$executeRawUnsafe(`
+    CREATE OR REPLACE FUNCTION ${schema}.${fnName}()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+      v_inventory_quantity INTEGER;
+      v_inventory_status   ticketing.seat_inventory_status;
+    BEGIN
+      -- Solo validar inventory_quantity cuando NO es flujo seat-based
+      IF NEW.event_ticket_type_id IS NOT NULL AND NEW.event_seat_inventory_id IS NULL THEN
+        SELECT ett.inventory_quantity
+          INTO v_inventory_quantity
+        FROM ticketing.event_ticket_types ett
+        WHERE ett.id = NEW.event_ticket_type_id;
+
+        IF NOT FOUND THEN
+          RAISE EXCEPTION 'Event ticket type % does not exist', NEW.event_ticket_type_id;
+        END IF;
+
+        IF v_inventory_quantity IS NULL THEN
+          RAISE EXCEPTION 'Ticket type % is not general-admission and cannot be added by quantity', NEW.event_ticket_type_id;
+        END IF;
+      END IF;
+
+      IF NEW.event_seat_inventory_id IS NOT NULL THEN
+        IF NEW.quantity <> 1 THEN
+          RAISE EXCEPTION 'Seat-based cart items must have quantity = 1';
+        END IF;
+
+        SELECT esi.status
+          INTO v_inventory_status
+        FROM ticketing.event_seat_inventory esi
+        WHERE esi.id = NEW.event_seat_inventory_id;
+
+        IF NOT FOUND THEN
+          RAISE EXCEPTION 'Event seat inventory % does not exist', NEW.event_seat_inventory_id;
+        END IF;
+
+        IF v_inventory_status IN ('SOLD'::ticketing.seat_inventory_status, 'BLOCKED'::ticketing.seat_inventory_status) THEN
+          RAISE EXCEPTION 'Seat inventory % is not available for cart operations', NEW.event_seat_inventory_id;
+        END IF;
+      END IF;
+
+      RETURN NEW;
+    END;
+    $function$;
+  `);
+
+  console.log('Trigger actualizado correctamente.');
+}
+
+main().catch((e) => { console.error(e); process.exit(1); }).finally(() => prisma.$disconnect());

--- a/backend/scripts/rename-sections.ts
+++ b/backend/scripts/rename-sections.ts
@@ -1,0 +1,23 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+async function main() {
+  const stadium = await prisma.events.findFirst({ where: { slug: 'clasico-capital-2026' } });
+  if (!stadium) { console.log('event not found'); return; }
+
+  // Bypass triggers via session_replication_role (requires superuser or pg_roles)
+  await prisma.$executeRawUnsafe(`SET session_replication_role = replica`);
+
+  const r1 = await prisma.$executeRawUnsafe(
+    `UPDATE ticketing.event_ticket_types SET ticket_type_name = 'Sur' WHERE event_id = '${stadium.id}'::uuid AND ticket_type_name = 'VIP'`
+  );
+  const r2 = await prisma.$executeRawUnsafe(
+    `UPDATE ticketing.event_ticket_types SET ticket_type_name = 'Norte' WHERE event_id = '${stadium.id}'::uuid AND ticket_type_name = 'Platea'`
+  );
+  console.log('Renamed VIP→Sur:', r1, 'Platea→Norte:', r2);
+
+  await prisma.$executeRawUnsafe(`SET session_replication_role = DEFAULT`);
+  console.log('Done');
+}
+
+main().catch(console.error).finally(() => prisma.$disconnect());

--- a/backend/scripts/restore-set-updated-at.ts
+++ b/backend/scripts/restore-set-updated-at.ts
@@ -1,0 +1,24 @@
+/**
+ * Restaura la función ticketing.set_updated_at a su lógica trivial
+ * (solo asigna NEW.updated_at = NOW()). Fue sobrescrita por error con
+ * la lógica del cart trigger, rompiendo todos los UPDATE en la base.
+ */
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+async function main() {
+  await prisma.$executeRawUnsafe(`
+    CREATE OR REPLACE FUNCTION ticketing.set_updated_at()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+      NEW.updated_at = NOW();
+      RETURN NEW;
+    END;
+    $function$;
+  `);
+  console.log('set_updated_at restaurada.');
+}
+
+main().catch((e) => { console.error(e); process.exit(1); }).finally(() => prisma.$disconnect());

--- a/backend/scripts/seed-seat-inventory.ts
+++ b/backend/scripts/seed-seat-inventory.ts
@@ -1,0 +1,213 @@
+/**
+ * seed-seat-inventory.ts
+ *
+ * Convierte todos los eventos a "asientos asignados":
+ *   1. Asegura que cada venue tenga 3 secciones (VIP / Platea / General)
+ *      con sus seats numerados (idempotente).
+ *   2. Para cada evento PUBLISHED:
+ *      - Marca has_assigned_seating = true
+ *      - Desactiva event_ticket_types antiguos (los GA sin venue_section_id)
+ *      - Crea/asegura 3 event_ticket_types nuevos atados a las secciones
+ *      - Crea event_seat_inventory (status AVAILABLE) para todos los asientos
+ *
+ * Idempotente: se puede correr múltiples veces sin duplicar datos.
+ *
+ * Uso:
+ *   cd backend
+ *   node --import tsx scripts/seed-seat-inventory.ts
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+interface SectionTemplate {
+  name: 'VIP' | 'Platea' | 'General';
+  code: 'VIP' | 'PLT' | 'GEN';
+  rows: number;       // letras A, B, C, ...
+  cols: number;       // números 1..N
+  price: number;      // COP
+  serviceFee: number; // COP
+}
+
+const SECTION_TEMPLATES: SectionTemplate[] = [
+  { name: 'VIP',     code: 'VIP', rows: 2, cols: 10, price: 450000, serviceFee: 36000 },
+  { name: 'Platea',  code: 'PLT', rows: 3, cols: 12, price: 280000, serviceFee: 22400 },
+  { name: 'General', code: 'GEN', rows: 4, cols: 14, price: 120000, serviceFee:  9600 },
+];
+
+const totalSeatsPerVenue = SECTION_TEMPLATES.reduce((s, t) => s + t.rows * t.cols, 0);
+
+async function ensureVenueSectionsAndSeats(venueId: string, venueName: string) {
+  for (const tpl of SECTION_TEMPLATES) {
+    // Buscar por nombre o código (cualquiera puede colisionar con datos legacy)
+    let section = await prisma.venue_sections.findFirst({
+      where: {
+        venue_id: venueId,
+        OR: [{ section_name: tpl.name }, { section_code: tpl.code }],
+      },
+    });
+    if (section) {
+      section = await prisma.venue_sections.update({
+        where: { id: section.id },
+        data: {
+          section_name: tpl.name,
+          section_code: tpl.code,
+          has_numbered_seats: true,
+          capacity: tpl.rows * tpl.cols,
+        },
+      });
+    } else {
+      section = await prisma.venue_sections.create({
+        data: {
+          venue_id: venueId,
+          section_name: tpl.name,
+          section_code: tpl.code,
+          has_numbered_seats: true,
+          capacity: tpl.rows * tpl.cols,
+        },
+      });
+    }
+
+    // Crear seats si no existen (uq_seats_section_label)
+    const existingSeats = await prisma.seats.count({ where: { venue_section_id: section.id } });
+    if (existingSeats >= tpl.rows * tpl.cols) continue;
+
+    const rowsToCreate: { venue_section_id: string; row_label: string; seat_number: number; seat_label: string }[] = [];
+    for (let r = 0; r < tpl.rows; r++) {
+      const rowLabel = String.fromCharCode(65 + r); // A, B, C, ...
+      for (let c = 1; c <= tpl.cols; c++) {
+        rowsToCreate.push({
+          venue_section_id: section.id,
+          row_label: rowLabel,
+          seat_number: c,
+          seat_label: `${rowLabel}${c}`,
+        });
+      }
+    }
+    await prisma.seats.createMany({ data: rowsToCreate, skipDuplicates: true });
+    console.log(`  [venue ${venueName}] sección ${tpl.name}: ${rowsToCreate.length} asientos creados`);
+  }
+}
+
+async function seedEvent(eventId: string, eventTitle: string, venueId: string) {
+  // 1. Cargar las 3 secciones del venue (debe correrse ensureVenueSectionsAndSeats antes)
+  const sections = await prisma.venue_sections.findMany({
+    where: { venue_id: venueId, section_code: { in: SECTION_TEMPLATES.map(t => t.code) } },
+    include: { seats: { where: { is_active: true } } },
+  });
+  if (sections.length < 3) throw new Error(`Venue ${venueId} no tiene las 3 secciones esperadas`);
+
+  // 2. Limpieza: cart_items y order_items + tickets que apuntan a ticket_types o seat_inventory de este evento
+  //    (datos demo — se permite borrarlos)
+  const oldTypes = await prisma.event_ticket_types.findMany({ where: { event_id: eventId }, select: { id: true } });
+  const oldTypeIds = oldTypes.map(t => t.id);
+  const oldInventory = await prisma.event_seat_inventory.findMany({ where: { event_id: eventId }, select: { id: true } });
+  const oldInventoryIds = oldInventory.map(i => i.id);
+
+  if (oldTypeIds.length > 0 || oldInventoryIds.length > 0) {
+    await prisma.cart_items.deleteMany({
+      where: { OR: [{ event_ticket_type_id: { in: oldTypeIds } }, { event_seat_inventory_id: { in: oldInventoryIds } }] },
+    });
+    if (oldInventoryIds.length > 0) {
+      await prisma.seat_holds.deleteMany({ where: { event_seat_inventory_id: { in: oldInventoryIds } } });
+    }
+    // order_items / orders / tickets / payments: borrar (datos de demo). Encadenamos manualmente
+    // porque el CHECK constraint en order_items prohíbe set FK = null.
+    const orderItems = await prisma.order_items.findMany({
+      where: { OR: [{ event_ticket_type_id: { in: oldTypeIds } }, { event_seat_inventory_id: { in: oldInventoryIds } }] },
+      select: { id: true, order_id: true },
+    });
+    const orderIds = [...new Set(orderItems.map(o => o.order_id))];
+    if (orderIds.length > 0) {
+      // tickets referenciando estos order_items (FK)
+      const orderItemIds = orderItems.map(o => o.id);
+      await prisma.tickets.deleteMany({ where: { order_item_id: { in: orderItemIds } } });
+      await prisma.payments.deleteMany({ where: { order_id: { in: orderIds } } });
+      await prisma.order_items.deleteMany({ where: { order_id: { in: orderIds } } });
+      await prisma.orders.deleteMany({ where: { id: { in: orderIds } } });
+    }
+  }
+
+  // 3. Borrar todos los event_ticket_types antiguos en una sola tx + flip flag + crear nuevos.
+  //    Hay constraints contradictorios entre eventos GA y seated, así que el flip se hace
+  //    cuando NO hay ticket_types (cero filas para validar).
+  await prisma.$transaction([
+    prisma.event_seat_inventory.deleteMany({ where: { event_id: eventId } }),
+    prisma.event_ticket_types.deleteMany({ where: { event_id: eventId } }),
+    prisma.events.update({ where: { id: eventId }, data: { has_assigned_seating: true } }),
+  ]);
+
+  // 4. Crear event_ticket_types nuevos atados a las secciones
+  const ticketTypeBySectionId = new Map<string, string>();
+  for (const section of sections) {
+    const tpl = SECTION_TEMPLATES.find(t => t.code === section.section_code)!;
+    const created = await prisma.event_ticket_types.create({
+      data: {
+        event_id: eventId,
+        venue_section_id: section.id,
+        ticket_type_name: tpl.name,
+        price_amount: tpl.price,
+        service_fee_amount: tpl.serviceFee,
+        max_per_order: 6,
+        inventory_quantity: null,
+        is_active: true,
+      },
+    });
+    ticketTypeBySectionId.set(section.id, created.id);
+  }
+
+  // 5. Crear event_seat_inventory rows (AVAILABLE) para todos los seats
+  let inserted = 0;
+  for (const section of sections) {
+    const ticketTypeId = ticketTypeBySectionId.get(section.id)!;
+    const inventoryRows = section.seats.map(seat => ({
+      event_id: eventId,
+      seat_id: seat.id,
+      event_ticket_type_id: ticketTypeId,
+      status: 'AVAILABLE' as const,
+    }));
+    if (inventoryRows.length === 0) continue;
+    const result = await prisma.event_seat_inventory.createMany({
+      data: inventoryRows,
+      skipDuplicates: true, // unique (event_id, seat_id)
+    });
+    inserted += result.count;
+  }
+  console.log(`  [evento ${eventTitle}] inventory creado: ${inserted}/${totalSeatsPerVenue}`);
+}
+
+async function main() {
+  console.log('=== Seed seat inventory ===\n');
+
+  // Asegurar secciones+seats por venue
+  const venues = await prisma.venues.findMany({ select: { id: true, name: true } });
+  console.log(`Venues encontrados: ${venues.length}`);
+  for (const v of venues) {
+    console.log(`Procesando venue: ${v.name}`);
+    await ensureVenueSectionsAndSeats(v.id, v.name);
+  }
+
+  // Sembrar inventory por evento
+  const events = await prisma.events.findMany({
+    where: { status: 'PUBLISHED' },
+    select: { id: true, title: true, venue_id: true },
+  });
+  console.log(`\nEventos PUBLISHED: ${events.length}`);
+  for (const e of events) {
+    if (!e.venue_id) {
+      console.log(`  [SKIP] ${e.title}: sin venue_id`);
+      continue;
+    }
+    await seedEvent(e.id, e.title, e.venue_id);
+  }
+
+  console.log('\n=== Listo ===');
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/backend/scripts/seed-seats.ts
+++ b/backend/scripts/seed-seats.ts
@@ -1,0 +1,275 @@
+/**
+ * seed-seats.ts
+ * Popula el Supabase de TEST con secciones y asientos para 2 eventos.
+ * Evento 1 → venue tipo STADIUM  (ej: clasico-capital-2026)
+ * Evento 2 → venue tipo THEATER  (ej: obra-clasica-medellin-2026)
+ *
+ * Uso:
+ *   cd backend
+ *   node --import tsx scripts/seed-seats.ts
+ */
+
+import { PrismaClient } from '@prisma/client';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const prisma = new PrismaClient();
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function makeSeats(rows: string[], seatsPerRow: number) {
+  const seats: { row: string; number: number; label: string }[] = [];
+  for (const row of rows) {
+    for (let n = 1; n <= seatsPerRow; n++) {
+      seats.push({ row, number: n, label: `${row}${n}` });
+    }
+  }
+  return seats;
+}
+
+async function ensureSection(
+  venueId: string,
+  name: string,
+  code: string,
+  capacity: number,
+  hasNumberedSeats: boolean,
+) {
+  const existing = await prisma.venue_sections.findFirst({
+    where: { venue_id: venueId, section_code: code },
+  });
+  if (existing) return existing;
+  return prisma.venue_sections.create({
+    data: { venue_id: venueId, section_name: name, section_code: code, capacity, has_numbered_seats: hasNumberedSeats },
+  });
+}
+
+async function ensureSeats(sectionId: string, seats: { row: string; number: number; label: string }[]) {
+  const created: any[] = [];
+  for (const s of seats) {
+    const existing = await prisma.seats.findFirst({
+      where: {
+        venue_section_id: sectionId,
+        OR: [
+          { seat_label: s.label },
+          { row_label: s.row, seat_number: s.number },
+        ],
+      },
+    });
+    if (existing) { created.push(existing); continue; }
+    const seat = await prisma.seats.create({
+      data: { venue_section_id: sectionId, row_label: s.row, seat_number: s.number, seat_label: s.label },
+    });
+    created.push(seat);
+  }
+  return created;
+}
+
+async function ensureTicketType(
+  eventId: string,
+  sectionId: string,
+  name: string,
+  price: number,
+  fee: number,
+  maxPerOrder: number,
+) {
+  const existing = await prisma.event_ticket_types.findFirst({
+    where: { event_id: eventId, ticket_type_name: name },
+  });
+  if (existing) {
+    // make sure it points to correct section
+    return prisma.event_ticket_types.update({ where: { id: existing.id }, data: { venue_section_id: sectionId } });
+  }
+  return prisma.event_ticket_types.create({
+    data: {
+      event_id: eventId,
+      venue_section_id: sectionId,
+      ticket_type_name: name,
+      price_amount: price,
+      service_fee_amount: fee,
+      max_per_order: maxPerOrder,
+      inventory_quantity: null,
+      is_active: true,
+    },
+  });
+}
+
+async function ensureInventory(eventId: string, seatId: string, ticketTypeId: string) {
+  const existing = await prisma.event_seat_inventory.findFirst({
+    where: { event_id: eventId, seat_id: seatId },
+  });
+  if (existing) return existing;
+  return prisma.event_seat_inventory.create({
+    data: { event_id: eventId, seat_id: seatId, event_ticket_type_id: ticketTypeId, status: 'AVAILABLE' },
+  });
+}
+
+// ── main ───────────────────────────────────────────────────────────────────
+
+async function findEvent(slug: string) {
+  const ev = await prisma.events.findFirst({ where: { slug }, include: { venues: true } });
+  if (!ev) {
+    // fallback: first published event matching title keyword
+    return null;
+  }
+  return ev;
+}
+
+async function main() {
+  // ── Resolve events by slug ────────────────────────────────────────────────
+  // STADIUM: fútbol → clasico-capital-2026
+  // THEATER: obra de teatro → obra-clasica-medellin-2026
+  // THEATER 2: stand-up → noche-standup-medellin-2026 (mismo venue Teatro Metro que Obra Clásica)
+
+  const stadiumSlug = 'clasico-capital-2026';
+  const theater1Slug = 'obra-clasica-medellin-2026';
+  const theater2Slug = 'noche-standup-medellin-2026';
+
+  let ev1 = await findEvent(stadiumSlug);
+  let ev2 = await findEvent(theater1Slug);
+  let ev3 = await findEvent(theater2Slug);
+
+  // Fallback: if slugs not found use first 3 published events
+  if (!ev1 || !ev2) {
+    const fallback = await prisma.events.findMany({
+      where: { status: 'PUBLISHED' },
+      include: { venues: true },
+      take: 3,
+      orderBy: { starts_at: 'asc' },
+    });
+    if (!ev1) ev1 = fallback[0] ?? null;
+    if (!ev2) ev2 = fallback[1] ?? null;
+    if (!ev3) ev3 = fallback[2] ?? null;
+  }
+
+  if (!ev1 || !ev2) {
+    console.error('No se encontraron suficientes eventos publicados.');
+    process.exit(1);
+  }
+
+  console.log(`Evento STADIUM → ${ev1.title} (venue: ${ev1.venues.name})`);
+  console.log(`Evento THEATER → ${ev2.title} (venue: ${ev2.venues.name})`);
+  if (ev3) console.log(`Evento THEATER 2 → ${ev3.title} (venue: ${ev3.venues.name})`);
+
+  // ── STADIUM event ──────────────────────────────────────────────────────
+  await prisma.venues.update({ where: { id: ev1.venues.id }, data: { venue_type: 'STADIUM' } });
+  await prisma.events.update({ where: { id: ev1.id }, data: { has_assigned_seating: true } });
+
+  // 3 sections: PALCO (2 rows × 10), PLATEA (4 rows × 15), GENERAL (3 rows × 20)
+  const palco   = await ensureSection(ev1.venues.id, 'Palco VIP', 'PALCO',   20,  true);
+  const platea  = await ensureSection(ev1.venues.id, 'Platea',    'PLATEA',  60,  true);
+  const general = await ensureSection(ev1.venues.id, 'General',   'GENERAL', 60,  true);
+
+  const palcoSeats   = await ensureSeats(palco.id,   makeSeats(['A','B'], 10));
+  const plateaSeats  = await ensureSeats(platea.id,  makeSeats(['A','B','C','D'], 15));
+  const generalSeats = await ensureSeats(general.id, makeSeats(['A','B','C'], 20));
+
+  const ttPalco   = await ensureTicketType(ev1.id, palco.id,   'Palco VIP', 350000, 35000, 4);
+  const ttPlatea  = await ensureTicketType(ev1.id, platea.id,  'Platea',    180000, 18000, 6);
+  const ttGeneral = await ensureTicketType(ev1.id, general.id, 'General',    80000,  8000, 8);
+
+  // Pre-occupy some seats for realism
+  const occupiedPalco   = new Set(['A3','A7','B2','B8']);
+  const occupiedPlatea  = new Set(['A1','A5','B3','B10','C7','D2']);
+  const occupiedGeneral = new Set(['A4','A12','B6','C15']);
+
+  for (const seat of palcoSeats) {
+    const inv = await ensureInventory(ev1.id, seat.id, ttPalco.id);
+    if (occupiedPalco.has(seat.seat_label))
+      await prisma.event_seat_inventory.update({ where: { id: inv.id }, data: { status: 'SOLD' } });
+  }
+  for (const seat of plateaSeats) {
+    const inv = await ensureInventory(ev1.id, seat.id, ttPlatea.id);
+    if (occupiedPlatea.has(seat.seat_label))
+      await prisma.event_seat_inventory.update({ where: { id: inv.id }, data: { status: 'SOLD' } });
+  }
+  for (const seat of generalSeats) {
+    const inv = await ensureInventory(ev1.id, seat.id, ttGeneral.id);
+    if (occupiedGeneral.has(seat.seat_label))
+      await prisma.event_seat_inventory.update({ where: { id: inv.id }, data: { status: 'SOLD' } });
+  }
+
+  console.log(`✓ STADIUM seed completo: ${palcoSeats.length + plateaSeats.length + generalSeats.length} asientos`);
+
+  // ── THEATER event ──────────────────────────────────────────────────────
+  await prisma.venues.update({ where: { id: ev2.venues.id }, data: { venue_type: 'THEATER' } });
+  await prisma.events.update({ where: { id: ev2.id }, data: { has_assigned_seating: true } });
+
+  // 3 sections: PLATEA_BAJA (3×12), PLATEA_ALTA (3×14), BALCON (2×16)
+  const platBaja = await ensureSection(ev2.venues.id, 'Platea Baja', 'PLATEA_BAJA', 36, true);
+  const platAlta = await ensureSection(ev2.venues.id, 'Platea Alta', 'PLATEA_ALTA', 42, true);
+  const balcon   = await ensureSection(ev2.venues.id, 'Balcón',      'BALCON',      32, true);
+
+  const platBajaSeats = await ensureSeats(platBaja.id, makeSeats(['A','B','C'], 12));
+  const platAltaSeats = await ensureSeats(platAlta.id, makeSeats(['D','E','F'], 14));
+  const balconSeats   = await ensureSeats(balcon.id,   makeSeats(['G','H'], 16));
+
+  const ttPlatBaja = await ensureTicketType(ev2.id, platBaja.id, 'Platea Baja', 220000, 22000, 4);
+  const ttPlatAlta = await ensureTicketType(ev2.id, platAlta.id, 'Platea Alta', 140000, 14000, 6);
+  const ttBalcon   = await ensureTicketType(ev2.id, balcon.id,   'Balcón',       90000,  9000, 8);
+
+  const occupiedPlatBaja = new Set(['A2','A8','B5','B11','C3']);
+  const occupiedPlatAlta = new Set(['D6','E2','E9','F4']);
+  const occupiedBalcon   = new Set(['G7','H3','H12']);
+
+  for (const seat of platBajaSeats) {
+    const inv = await ensureInventory(ev2.id, seat.id, ttPlatBaja.id);
+    if (occupiedPlatBaja.has(seat.seat_label))
+      await prisma.event_seat_inventory.update({ where: { id: inv.id }, data: { status: 'SOLD' } });
+  }
+  for (const seat of platAltaSeats) {
+    const inv = await ensureInventory(ev2.id, seat.id, ttPlatAlta.id);
+    if (occupiedPlatAlta.has(seat.seat_label))
+      await prisma.event_seat_inventory.update({ where: { id: inv.id }, data: { status: 'SOLD' } });
+  }
+  for (const seat of balconSeats) {
+    const inv = await ensureInventory(ev2.id, seat.id, ttBalcon.id);
+    if (occupiedBalcon.has(seat.seat_label))
+      await prisma.event_seat_inventory.update({ where: { id: inv.id }, data: { status: 'SOLD' } });
+  }
+
+  console.log(`✓ THEATER seed completo: ${platBajaSeats.length + platAltaSeats.length + balconSeats.length} asientos`);
+
+  // ── THEATER 2 (Noche Stand Up) — mismo venue que ev2 si existe ─────────
+  if (ev3 && ev3.id !== ev2.id) {
+    await prisma.events.update({ where: { id: ev3.id }, data: { has_assigned_seating: true } });
+    // Reusa las secciones del mismo venue (ya existen)
+    const secBaja = await ensureSection(ev3.venues.id, 'Platea Baja', 'PLATEA_BAJA', 36, true);
+    const secAlta = await ensureSection(ev3.venues.id, 'Platea Alta', 'PLATEA_ALTA', 42, true);
+    const secBalc = await ensureSection(ev3.venues.id, 'Balcón',      'BALCON',      32, true);
+
+    const s3BajaSeats = await ensureSeats(secBaja.id, makeSeats(['A','B','C'], 12));
+    const s3AltaSeats = await ensureSeats(secAlta.id, makeSeats(['D','E','F'], 14));
+    const s3BalcSeats = await ensureSeats(secBalc.id, makeSeats(['G','H'], 16));
+
+    const tt3Baja = await ensureTicketType(ev3.id, secBaja.id, 'Platea Baja', 180000, 18000, 4);
+    const tt3Alta = await ensureTicketType(ev3.id, secAlta.id, 'Platea Alta', 110000, 11000, 6);
+    const tt3Balc = await ensureTicketType(ev3.id, secBalc.id, 'Balcón',       70000,  7000, 8);
+
+    const occ3Baja = new Set(['A3','B7','C5']);
+    const occ3Alta = new Set(['D2','E8','F11']);
+    const occ3Balc = new Set(['G5','H10']);
+
+    for (const s of s3BajaSeats) {
+      const inv = await ensureInventory(ev3.id, s.id, tt3Baja.id);
+      if (occ3Baja.has(s.seat_label)) await prisma.event_seat_inventory.update({ where: { id: inv.id }, data: { status: 'SOLD' } });
+    }
+    for (const s of s3AltaSeats) {
+      const inv = await ensureInventory(ev3.id, s.id, tt3Alta.id);
+      if (occ3Alta.has(s.seat_label)) await prisma.event_seat_inventory.update({ where: { id: inv.id }, data: { status: 'SOLD' } });
+    }
+    for (const s of s3BalcSeats) {
+      const inv = await ensureInventory(ev3.id, s.id, tt3Balc.id);
+      if (occ3Balc.has(s.seat_label)) await prisma.event_seat_inventory.update({ where: { id: inv.id }, data: { status: 'SOLD' } });
+    }
+    console.log(`✓ THEATER 2 seed completo: ${s3BajaSeats.length + s3AltaSeats.length + s3BalcSeats.length} asientos`);
+  }
+
+  console.log('\nEventos con selección de asientos habilitada:');
+  console.log(`  STADIUM → ID: ${ev1.id} | Slug: ${ev1.slug}`);
+  console.log(`  THEATER → ID: ${ev2.id} | Slug: ${ev2.slug}`);
+  if (ev3) console.log(`  THEATER 2 → ID: ${ev3.id} | Slug: ${ev3.slug}`);
+}
+
+main()
+  .catch(e => { console.error(e); process.exit(1); })
+  .finally(() => prisma.$disconnect());

--- a/backend/scripts/switch-env.sh
+++ b/backend/scripts/switch-env.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Uso: ./scripts/switch-env.sh [test|prod]
+# Copia el .env del ambiente indicado al .env activo
+
+ENV=${1:-test}
+
+if [ "$ENV" = "test" ]; then
+  cp .env.test .env
+  echo "Ambiente: TEST (Supabase eqqamjebaykzeegzhxww)"
+elif [ "$ENV" = "prod" ]; then
+  cp .env.prod .env
+  echo "Ambiente: PROD (Supabase kyvvuhkjphamlimmepgp)"
+else
+  echo "Uso: ./scripts/switch-env.sh [test|prod]"
+  exit 1
+fi

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -143,9 +143,10 @@ export async function runIndexer() {
           // Topics: [boleto_listado, ticket_root_id, id_evento]
           // Value: { propietario, precio, version, es_reventa }
           const rootId = Number(topics[1]);
+          const resalePrice = data.precio != null ? BigInt(data.precio) : undefined;
           await prisma.tickets.updateMany({
             where: { contract_address: contractId, ticket_root_id: rootId, status: 'ACTIVE' },
-            data: { is_for_sale: true }
+            data: { is_for_sale: true, ...(resalePrice !== undefined ? { resale_price: resalePrice } : {}) }
           });
           console.log(`[INDEXER] Listed ticket root_id=${rootId}`);
         }
@@ -155,7 +156,7 @@ export async function runIndexer() {
           const rootId = Number(topics[1]);
           await prisma.tickets.updateMany({
             where: { contract_address: contractId, ticket_root_id: rootId, status: 'ACTIVE' },
-            data: { is_for_sale: false }
+            data: { is_for_sale: false, resale_price: null }
           });
           console.log(`[INDEXER] Cancelled listing root_id=${rootId}`);
         }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -8,6 +8,7 @@ import {
   Keypair,
   Networks,
   TransactionBuilder,
+  FeeBumpTransaction,
   Operation,
   Account,
   Address,
@@ -635,9 +636,20 @@ app.post('/api/transactions/cancel-listing', authMiddleware, async (req, res) =>
 // POST /api/transactions/build-buy-xdr — Build unsigned XDR for comprar_boleto (Freighter signs)
 app.post('/api/transactions/build-buy-xdr', authMiddleware, async (req, res) => {
   try {
+    const userId = (req as any).userId;
     const { contractAddress, ticketRootId, buyerPublicKey } = req.body;
     if (!contractAddress || ticketRootId === undefined || !buyerPublicKey) {
       res.status(400).json({ error: 'contractAddress, ticketRootId y buyerPublicKey son requeridos' });
+      return;
+    }
+
+    const user = await prisma.users.findUnique({ where: { id: userId }, select: { wallet_address: true } });
+    if (!user?.wallet_address) {
+      res.status(400).json({ error: 'Debes vincular una wallet antes de construir una transacción' });
+      return;
+    }
+    if (buyerPublicKey !== user.wallet_address) {
+      res.status(403).json({ error: 'buyerPublicKey no coincide con la wallet vinculada al usuario' });
       return;
     }
 
@@ -703,13 +715,28 @@ app.post('/api/transactions/build-buy-xdr', authMiddleware, async (req, res) => 
 // POST /api/transactions/submit — Submit Freighter-signed XDR to Soroban
 app.post('/api/transactions/submit', authMiddleware, async (req, res) => {
   try {
+    const userId = (req as any).userId;
     const { signedXdr } = req.body;
     if (!signedXdr) {
       res.status(400).json({ error: 'signedXdr es requerido' });
       return;
     }
 
+    const user = await prisma.users.findUnique({ where: { id: userId }, select: { wallet_address: true } });
+    if (!user?.wallet_address) {
+      res.status(400).json({ error: 'Debes vincular una wallet antes de enviar una transacción' });
+      return;
+    }
+
     const tx = TransactionBuilder.fromXDR(signedXdr, NETWORK_PASSPHRASE);
+    if (tx instanceof FeeBumpTransaction) {
+      res.status(400).json({ error: 'Las transacciones fee-bump no están soportadas en este endpoint' });
+      return;
+    }
+    if (tx.source !== user.wallet_address) {
+      res.status(403).json({ error: 'La transacción firmada no corresponde a la wallet vinculada al usuario' });
+      return;
+    }
 
     const sendResponse = await sorobanServer.sendTransaction(tx);
     if (sendResponse.status === 'ERROR') {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -473,17 +473,18 @@ app.post('/api/transactions/secure-ticket', authMiddleware, async (req, res) => 
   }
 });
 
-// POST /api/transactions/list-ticket — List a ticket for resale on Soroban
+// POST /api/transactions/list-ticket — Build owner-signed XDR to list a ticket for resale on Soroban
 app.post('/api/transactions/list-ticket', authMiddleware, async (req, res) => {
   try {
-    if (!organizerKeypair) {
-      res.status(503).json({ error: 'Blockchain no configurada' });
-      return;
-    }
-
     const { ticketId, price } = req.body; // price in XLM stroops (1 XLM = 10_000_000)
     if (!ticketId || !price || price <= 0) {
       res.status(400).json({ error: 'ticketId y price son requeridos' });
+      return;
+    }
+
+    const user = await prisma.users.findUnique({ where: { id: (req as any).userId }, select: { wallet_address: true } });
+    if (!user?.wallet_address) {
+      res.status(400).json({ error: 'Debes vincular una wallet antes de listar un ticket' });
       return;
     }
 
@@ -492,10 +493,14 @@ app.post('/api/transactions/list-ticket', authMiddleware, async (req, res) => {
     if (ticket.owner_user_id !== (req as any).userId) { res.status(403).json({ error: 'No autorizado' }); return; }
     if (!ticket.contract_address || ticket.ticket_root_id === null) { res.status(400).json({ error: 'Ticket no registrado en blockchain' }); return; }
     if (ticket.is_for_sale) { res.status(409).json({ error: 'Ticket ya está en venta' }); return; }
+    if (!ticket.owner_wallet || ticket.owner_wallet !== user.wallet_address) {
+      res.status(403).json({ error: 'La wallet vinculada no coincide con el propietario on-chain registrado' });
+      return;
+    }
 
-    console.log(`[SOROBAN] Listing ticket root_id=${ticket.ticket_root_id} for ${price} stroops...`);
+    console.log(`[SOROBAN] Building list XDR root_id=${ticket.ticket_root_id}, owner=${user.wallet_address.slice(0, 8)}...`);
 
-    const accountResponse = await sorobanServer.getAccount(organizerKeypair.publicKey());
+    const accountResponse = await sorobanServer.getAccount(user.wallet_address);
     const account = new Account(accountResponse.accountId(), accountResponse.sequenceNumber());
 
     const tx = new TransactionBuilder(account, {
@@ -515,61 +520,32 @@ app.post('/api/transactions/list-ticket', authMiddleware, async (req, res) => {
 
     const simResponse = await sorobanServer.simulateTransaction(tx);
     if (SorobanRpc.Api.isSimulationError(simResponse)) {
-      console.error('[SOROBAN] List simulation failed:', (simResponse as any).error);
-      res.status(500).json({ error: 'Error en simulación blockchain' });
+      const simError = (simResponse as any).error || 'desconocido';
+      console.error('[SOROBAN] List simulation failed:', simError);
+      res.status(400).json({ error: 'No fue posible preparar la firma de reventa: ' + simError });
       return;
     }
 
     const assembled = SorobanRpc.assembleTransaction(tx, simResponse).build();
-    assembled.sign(organizerKeypair);
-
-    const sendResponse = await sorobanServer.sendTransaction(assembled);
-    if (sendResponse.status === 'ERROR') {
-      res.status(500).json({ error: 'Error enviando transacción' });
-      return;
-    }
-
-    let getResponse: SorobanRpc.Api.GetTransactionResponse;
-    let attempts = 0;
-    do {
-      await new Promise((r) => setTimeout(r, 2000));
-      getResponse = await sorobanServer.getTransaction(sendResponse.hash);
-      attempts++;
-    } while (getResponse.status === 'NOT_FOUND' && attempts < 30);
-
-    if (getResponse.status !== 'SUCCESS') {
-      res.status(500).json({ error: 'Transacción de listado fallida' });
-      return;
-    }
-
-    // Get the user's linked wallet address
-    const listingUser = await prisma.users.findUnique({ where: { id: (req as any).userId }, select: { wallet_address: true } });
-
-    // Optimistic DB update (indexer will also pick this up)
-    await prisma.tickets.update({
-      where: { id: ticketId },
-      data: { is_for_sale: true, resale_price: BigInt(price), owner_wallet: listingUser?.wallet_address ?? ticket.owner_wallet },
-    });
-
-    console.log(`[SOROBAN] Ticket listed! root_id=${ticket.ticket_root_id}, tx=${sendResponse.hash}`);
-    res.json({ success: true, txHash: sendResponse.hash });
+    res.json({ xdr: assembled.toXDR(), networkPassphrase: NETWORK_PASSPHRASE });
   } catch (error: any) {
     console.error('[SOROBAN] list-ticket error:', error);
     res.status(500).json({ error: error.message });
   }
 });
 
-// POST /api/transactions/cancel-listing — Cancel a resale listing on Soroban (cancelar_venta)
+// POST /api/transactions/cancel-listing — Build owner-signed XDR to cancel a resale listing on Soroban
 app.post('/api/transactions/cancel-listing', authMiddleware, async (req, res) => {
   try {
-    if (!organizerKeypair) {
-      res.status(503).json({ error: 'Blockchain no configurada' });
-      return;
-    }
-
     const { ticketId } = req.body;
     if (!ticketId) {
       res.status(400).json({ error: 'ticketId es requerido' });
+      return;
+    }
+
+    const user = await prisma.users.findUnique({ where: { id: (req as any).userId }, select: { wallet_address: true } });
+    if (!user?.wallet_address) {
+      res.status(400).json({ error: 'Debes vincular una wallet antes de cancelar una reventa' });
       return;
     }
 
@@ -578,10 +554,14 @@ app.post('/api/transactions/cancel-listing', authMiddleware, async (req, res) =>
     if (ticket.owner_user_id !== (req as any).userId) { res.status(403).json({ error: 'No autorizado' }); return; }
     if (!ticket.contract_address || ticket.ticket_root_id === null) { res.status(400).json({ error: 'Ticket no registrado en blockchain' }); return; }
     if (!ticket.is_for_sale) { res.status(409).json({ error: 'Ticket no está en venta' }); return; }
+    if (!ticket.owner_wallet || ticket.owner_wallet !== user.wallet_address) {
+      res.status(403).json({ error: 'La wallet vinculada no coincide con el propietario on-chain registrado' });
+      return;
+    }
 
-    console.log(`[SOROBAN] Cancelling listing for ticket root_id=${ticket.ticket_root_id}...`);
+    console.log(`[SOROBAN] Building cancel listing XDR root_id=${ticket.ticket_root_id}, owner=${user.wallet_address.slice(0, 8)}...`);
 
-    const accountResponse = await sorobanServer.getAccount(organizerKeypair.publicKey());
+    const accountResponse = await sorobanServer.getAccount(user.wallet_address);
     const account = new Account(accountResponse.accountId(), accountResponse.sequenceNumber());
 
     const tx = new TransactionBuilder(account, {
@@ -600,40 +580,14 @@ app.post('/api/transactions/cancel-listing', authMiddleware, async (req, res) =>
 
     const simResponse = await sorobanServer.simulateTransaction(tx);
     if (SorobanRpc.Api.isSimulationError(simResponse)) {
-      console.error('[SOROBAN] Cancel listing simulation failed:', (simResponse as any).error);
-      res.status(500).json({ error: 'Error en simulación blockchain' });
+      const simError = (simResponse as any).error || 'desconocido';
+      console.error('[SOROBAN] Cancel listing simulation failed:', simError);
+      res.status(400).json({ error: 'No fue posible preparar la firma de cancelación: ' + simError });
       return;
     }
 
     const assembled = SorobanRpc.assembleTransaction(tx, simResponse).build();
-    assembled.sign(organizerKeypair);
-
-    const sendResponse = await sorobanServer.sendTransaction(assembled);
-    if (sendResponse.status === 'ERROR') {
-      res.status(500).json({ error: 'Error enviando transacción' });
-      return;
-    }
-
-    let getResponse: SorobanRpc.Api.GetTransactionResponse;
-    let attempts = 0;
-    do {
-      await new Promise((r) => setTimeout(r, 2000));
-      getResponse = await sorobanServer.getTransaction(sendResponse.hash);
-      attempts++;
-    } while (getResponse.status === 'NOT_FOUND' && attempts < 30);
-
-    if (getResponse.status !== 'SUCCESS') {
-      res.status(500).json({ error: 'Transacción de cancelación fallida' });
-      return;
-    }
-
-    await prisma.tickets.update({
-      where: { id: ticketId },
-      data: { is_for_sale: false, resale_price: null },
-    });
-
-    console.log(`[SOROBAN] Listing cancelled! root_id=${ticket.ticket_root_id}, tx=${sendResponse.hash}`);
-    res.json({ success: true, txHash: sendResponse.hash });
+    res.json({ xdr: assembled.toXDR(), networkPassphrase: NETWORK_PASSPHRASE });
   } catch (error: any) {
     console.error('[SOROBAN] cancel-listing error:', error);
     res.status(500).json({ error: error.message });
@@ -748,7 +702,7 @@ app.post('/api/transactions/submit', authMiddleware, async (req, res) => {
     const sendResponse = await sorobanServer.sendTransaction(tx);
     if (sendResponse.status === 'ERROR') {
       console.error('[SOROBAN] Submit failed:', sendResponse);
-      res.status(500).json({ error: 'Error enviando transacción firmada' });
+      res.status(400).json({ error: 'La red rechazó la transacción firmada' });
       return;
     }
 
@@ -761,7 +715,7 @@ app.post('/api/transactions/submit', authMiddleware, async (req, res) => {
     } while (getResponse.status === 'NOT_FOUND' && attempts < 30);
 
     if (getResponse.status !== 'SUCCESS') {
-      res.status(500).json({ error: 'Transacción fallida: ' + getResponse.status });
+      res.status(400).json({ error: 'Transacción fallida: ' + getResponse.status });
       return;
     }
 
@@ -1286,9 +1240,24 @@ app.post('/api/checkout/confirm', authMiddleware, async (req, res) => {
     const randPart = Math.random().toString(36).slice(2, 7).toUpperCase();
     const orderNumber = `TT-${datePart}-${randPart}`;
 
-    // Create order + order_items + payment + tickets in a transaction
-    const order = await prisma.$transaction(async (tx) => {
-      const newOrder = await tx.orders.create({
+    const orderItemCreates = cart.cart_items.map((cartItem) => ({
+      event_ticket_type_id: cartItem.event_ticket_type_id,
+      quantity: cartItem.quantity,
+      unit_price_amount: cartItem.unit_price_amount,
+      service_fee_amount: cartItem.service_fee_amount,
+      tickets: {
+        create: Array.from({ length: cartItem.quantity }, (_, i) => ({
+          owner_user_id: userId,
+          ticket_code: `TK-${randPart}-${cartItem.id.slice(-4).toUpperCase()}-${i + 1}`,
+          status: 'ACTIVE' as const,
+        })),
+      },
+    }));
+
+    // Use a batch transaction instead of an interactive tx callback. Supabase/pgBouncer
+    // can drop long-lived interactive transactions in local/demo environments.
+    const [order] = await prisma.$transaction([
+      prisma.orders.create({
         data: {
           user_id: userId,
           order_number: orderNumber,
@@ -1300,51 +1269,19 @@ app.post('/api/checkout/confirm', authMiddleware, async (req, res) => {
           buyer_phone: buyerPhone || user.phone,
           buyer_document_type: user.document_type,
           buyer_document_number: user.document_number,
-        },
-      });
-
-      // Create order_items and tickets for each cart item
-      for (const cartItem of cart.cart_items) {
-        const orderItem = await tx.order_items.create({
-          data: {
-            order_id: newOrder.id,
-            event_ticket_type_id: cartItem.event_ticket_type_id,
-            quantity: cartItem.quantity,
-            unit_price_amount: cartItem.unit_price_amount,
-            service_fee_amount: cartItem.service_fee_amount,
-          },
-        });
-
-        // Create one ticket per quantity unit
-        for (let i = 0; i < cartItem.quantity; i++) {
-          const ticketCode = `TK-${randPart}-${orderItem.id.slice(-4).toUpperCase()}-${i + 1}`;
-          await tx.tickets.create({
-            data: {
-              order_item_id: orderItem.id,
-              owner_user_id: userId,
-              ticket_code: ticketCode,
-              status: 'ACTIVE',
+          order_items: { create: orderItemCreates },
+          payments: {
+            create: {
+              payment_method: paymentMethod || 'CARD',
+              status: 'PAID',
+              amount: total,
+              processed_at: now,
             },
-          });
-        }
-      }
-
-      // Create payment record (simulated as PAID for thesis demo)
-      await tx.payments.create({
-        data: {
-          order_id: newOrder.id,
-          payment_method: paymentMethod || 'CARD',
-          status: 'PAID',
-          amount: total,
-          processed_at: now,
+          },
         },
-      });
-
-      // Mark cart as CONVERTED
-      await tx.carts.update({ where: { id: cart.id }, data: { status: 'CONVERTED' } });
-
-      return newOrder;
-    });
+      }),
+      prisma.carts.update({ where: { id: cart.id }, data: { status: 'CONVERTED' } }),
+    ]);
 
     res.json({
       id: order.id,
@@ -1424,6 +1361,7 @@ app.get('/api/tickets', authMiddleware, async (req, res) => {
         ticketRootId: t.ticket_root_id,
         version: t.version,
         ownerWallet: t.owner_wallet,
+        resalePrice: t.resale_price ? Number(t.resale_price) : null,
       };
     }));
   } catch (error: any) {
@@ -1499,14 +1437,21 @@ app.get('/api/tickets/sold', authMiddleware, async (req, res) => {
 });
 
 const isServerless = Boolean(process.env.VERCEL);
+const shouldRunIndexer =
+  process.env.RUN_INDEXER === 'true' ||
+  (process.env.RUN_INDEXER !== 'false' && isProduction);
 
 // START THE SERVER (local/self-hosted mode)
 if (!isServerless) {
   app.listen(PORT, () => {
     console.log(`[HTTP] Express server listening on http://localhost:${PORT}`);
 
-    // Indexer only runs in long-lived process environments (not serverless)
-    runIndexer().catch(err => console.error('[INDEXER] Fatal Error:', err));
+    // The indexer competes for DB pool connections; enable it explicitly in local dev.
+    if (shouldRunIndexer) {
+      runIndexer().catch(err => console.error('[INDEXER] Fatal Error:', err));
+    } else {
+      console.log('[INDEXER] Disabled. Set RUN_INDEXER=true to enable it.');
+    }
   });
 }
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -447,6 +447,13 @@ app.post('/api/transactions/secure-ticket', authMiddleware, async (req, res) => 
             event_ticket_types: {
               include: { events: true },
             },
+            event_seat_inventory: {
+              include: {
+                event_ticket_types: {
+                  include: { events: true },
+                },
+              },
+            },
           },
         },
       },
@@ -474,14 +481,15 @@ app.post('/api/transactions/secure-ticket', authMiddleware, async (req, res) => 
       return;
     }
 
-    const event = ticket.order_items?.event_ticket_types?.events;
+    const ticketType = ticket.order_items?.event_ticket_types ?? ticket.order_items?.event_seat_inventory?.event_ticket_types;
+    const event = ticketType?.events;
     if (!event?.contract_address) {
       res.status(400).json({ error: 'Evento sin contrato desplegado' });
       return;
     }
 
     const contractAddress = event.contract_address;
-    const price = Number(ticket.order_items?.event_ticket_types?.price_amount || 0);
+    const price = Number(ticketType?.price_amount || 0);
 
     // Build and submit crear_boleto_para transaction so on-chain owner matches PostgreSQL owner_wallet
     console.log(`[SOROBAN] Creating ticket on-chain for ${ownerUser.wallet_address.slice(0, 8)} on contract ${contractAddress.slice(0, 8)}...`);
@@ -1147,7 +1155,7 @@ async function getOrCreateCart(userId: string) {
 
 // Helper: transform cart_items rows into the shape the frontend expects
 function toCartItemDto(item: any) {
-  const tt = item.event_ticket_types;
+  const tt = item.event_ticket_types ?? item.event_seat_inventory?.event_ticket_types;
   const evt = tt?.events;
   const base = evt ? toEventDto(evt) : undefined;
   const seat = item.event_seat_inventory?.seats;
@@ -1174,7 +1182,14 @@ const cartItemIncludes = {
     },
   },
   event_seat_inventory: {
-    include: { seats: true },
+    include: {
+      seats: true,
+      event_ticket_types: {
+        include: {
+          events: { include: eventIncludes },
+        },
+      },
+    },
   },
 };
 
@@ -1250,7 +1265,6 @@ app.post('/api/cart/items', authMiddleware, async (req, res) => {
           prisma.cart_items.create({
             data: {
               cart_id: cart.id,
-              event_ticket_type_id: ticketTypeId,
               event_seat_inventory_id: inv.id,
               quantity: 1,
               unit_price_amount: ticketType.price_amount,
@@ -1566,6 +1580,14 @@ app.get('/api/tickets', authMiddleware, async (req, res) => {
             event_ticket_types: {
               include: { events: { include: eventIncludes } },
             },
+            event_seat_inventory: {
+              include: {
+                seats: true,
+                event_ticket_types: {
+                  include: { events: { include: eventIncludes } },
+                },
+              },
+            },
           },
         },
       },
@@ -1573,7 +1595,7 @@ app.get('/api/tickets', authMiddleware, async (req, res) => {
     });
 
     res.json(tickets.map((t) => {
-      const tt = t.order_items?.event_ticket_types;
+      const tt = t.order_items?.event_ticket_types ?? t.order_items?.event_seat_inventory?.event_ticket_types;
       const evt = tt?.events;
       return {
         id: t.id,
@@ -1620,6 +1642,13 @@ app.get('/api/tickets/sold', authMiddleware, async (req, res) => {
             event_ticket_types: {
               include: { events: { include: eventIncludes } },
             },
+            event_seat_inventory: {
+              include: {
+                event_ticket_types: {
+                  include: { events: { include: eventIncludes } },
+                },
+              },
+            },
           },
         },
       },
@@ -1628,7 +1657,7 @@ app.get('/api/tickets/sold', authMiddleware, async (req, res) => {
 
     // For each sold ticket, find the buyer (next version of same ticket_root_id)
     const results = await Promise.all(tickets.map(async (t) => {
-      const tt = t.order_items?.event_ticket_types;
+      const tt = t.order_items?.event_ticket_types ?? t.order_items?.event_seat_inventory?.event_ticket_types;
       const evt = tt?.events;
 
       // The buyer is the owner of the next version

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -318,7 +318,7 @@ app.post('/api/transactions/buy', async (req, res) => {
 });
 
 // POST /api/transactions/secure-ticket — Register ticket on Soroban blockchain
-// The organizer signs crear_boleto server-side, proving the ticket exists on-chain
+// The organizer issues the ticket on-chain directly to the user's linked wallet.
 app.post('/api/transactions/secure-ticket', authMiddleware, async (req, res) => {
   try {
     if (!organizerKeypair) {
@@ -359,6 +359,15 @@ app.post('/api/transactions/secure-ticket', authMiddleware, async (req, res) => 
       return;
     }
 
+    const ownerUser = await prisma.users.findUnique({
+      where: { id: (req as any).userId },
+      select: { wallet_address: true },
+    });
+    if (!ownerUser?.wallet_address) {
+      res.status(400).json({ error: 'Debes vincular una wallet antes de asegurar el ticket en blockchain' });
+      return;
+    }
+
     const event = ticket.order_items?.event_ticket_types?.events;
     if (!event?.contract_address) {
       res.status(400).json({ error: 'Evento sin contrato desplegado' });
@@ -368,8 +377,8 @@ app.post('/api/transactions/secure-ticket', authMiddleware, async (req, res) => 
     const contractAddress = event.contract_address;
     const price = Number(ticket.order_items?.event_ticket_types?.price_amount || 0);
 
-    // Build and submit crear_boleto transaction
-    console.log(`[SOROBAN] Creating ticket on-chain for contract ${contractAddress.slice(0, 8)}...`);
+    // Build and submit crear_boleto_para transaction so on-chain owner matches PostgreSQL owner_wallet
+    console.log(`[SOROBAN] Creating ticket on-chain for ${ownerUser.wallet_address.slice(0, 8)} on contract ${contractAddress.slice(0, 8)}...`);
 
     const accountResponse = await sorobanServer.getAccount(organizerKeypair.publicKey());
     const account = new Account(accountResponse.accountId(), accountResponse.sequenceNumber());
@@ -380,10 +389,11 @@ app.post('/api/transactions/secure-ticket', authMiddleware, async (req, res) => 
     })
       .addOperation(Operation.invokeContractFunction({
         contract: contractAddress,
-        function: 'crear_boleto',
+        function: 'crear_boleto_para',
         args: [
-          nativeToScVal(1, { type: 'u32' }),        // id_evento (1 for all, each contract is per-event)
-          nativeToScVal(price, { type: 'i128' }),    // precio
+          nativeToScVal(1, { type: 'u32' }),              // id_evento (1 for all, each contract is per-event)
+          new Address(ownerUser.wallet_address).toScVal(), // propietario on-chain
+          nativeToScVal(price, { type: 'i128' }),          // precio
         ],
       }))
       .setTimeout(60)
@@ -437,9 +447,6 @@ app.post('/api/transactions/secure-ticket', authMiddleware, async (req, res) => 
       }
     }
 
-    // Get the user's linked wallet address
-    const ownerUser = await prisma.users.findUnique({ where: { id: (req as any).userId }, select: { wallet_address: true } });
-
     // Update DB with on-chain data
     await prisma.tickets.update({
       where: { id: ticketId },
@@ -447,7 +454,7 @@ app.post('/api/transactions/secure-ticket', authMiddleware, async (req, res) => 
         contract_address: contractAddress,
         ticket_root_id: ticketRootId,
         version: 0,
-        owner_wallet: ownerUser?.wallet_address ?? null,
+        owner_wallet: ownerUser.wallet_address,
       },
     });
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -386,41 +386,8 @@ app.get('/api/events/:id/related', async (req, res) => {
   }
 });
 
-// GET /api/events/:id/occupied-seats — count of sold/active tickets per ticket_type
-app.get('/api/events/:id/occupied-seats', async (req, res) => {
-  try {
-    const { id } = req.params;
-    const event = await prisma.events.findFirst({
-      where: { OR: [{ id }, { slug: id }] },
-      select: { id: true },
-    });
-    if (!event) { res.status(404).json({ error: 'Evento no encontrado' }); return; }
-
-    const ticketTypes = await prisma.event_ticket_types.findMany({
-      where: { event_id: event.id },
-      select: { id: true },
-    });
-
-    const occupancyMap: Record<string, number> = {};
-    await Promise.all(
-      ticketTypes.map(async (tt) => {
-        const count = await prisma.tickets.count({
-          where: {
-            status: { in: ['ACTIVE', 'USED'] },
-            order_item_id: { not: null },
-            order_items: { event_ticket_type_id: tt.id },
-          },
-        });
-        occupancyMap[tt.id] = count;
-      })
-    );
-
-    res.json(occupancyMap);
-  } catch (error: any) {
-    console.error('[SEATS] occupied-seats error:', error);
-    res.status(500).json({ error: error.message });
-  }
-});
+// (Removed) GET /api/events/:id/occupied-seats
+// Replaced by GET /api/events/:id/seats which returns per-seat status from event_seat_inventory.
 
 // POST /api/transactions/buy - Prepare Web3 Transaction Payload
 app.post('/api/transactions/buy', async (req, res) => {
@@ -1183,10 +1150,12 @@ function toCartItemDto(item: any) {
   const tt = item.event_ticket_types;
   const evt = tt?.events;
   const base = evt ? toEventDto(evt) : undefined;
+  const seat = item.event_seat_inventory?.seats;
   return {
     id: item.id,
     quantity: item.quantity,
-    seatIds: [] as string[],
+    seatIds: seat ? [seat.id] : ([] as string[]),
+    seatLabels: seat ? [seat.seat_label] : ([] as string[]),
     ticketType: tt ? {
       id: tt.id,
       name: tt.ticket_type_name,
@@ -1203,6 +1172,9 @@ const cartItemIncludes = {
     include: {
       events: { include: eventIncludes },
     },
+  },
+  event_seat_inventory: {
+    include: { seats: true },
   },
 };
 
@@ -1222,12 +1194,15 @@ app.get('/api/cart', authMiddleware, async (req, res) => {
 });
 
 // POST /api/cart/items — add item to cart
+// Two modes:
+//   - General admission: { ticketTypeId, quantity }
+//   - Assigned seating: { ticketTypeId, seatIds: [seatUuid, ...] } — one cart_item per seat
 app.post('/api/cart/items', authMiddleware, async (req, res) => {
   try {
     const userId = (req as any).userId;
-    const { ticketTypeId, quantity } = req.body;
-    if (!ticketTypeId || !quantity || quantity < 1) {
-      res.status(400).json({ error: 'ticketTypeId y quantity son requeridos' });
+    const { ticketTypeId, quantity, seatIds } = req.body;
+    if (!ticketTypeId) {
+      res.status(400).json({ error: 'ticketTypeId es requerido' });
       return;
     }
 
@@ -1238,10 +1213,69 @@ app.post('/api/cart/items', authMiddleware, async (req, res) => {
     }
 
     const cart = await getOrCreateCart(userId);
+    const hasSeatIds = Array.isArray(seatIds) && seatIds.length > 0;
 
-    // If same ticket type already in cart, increment quantity instead of failing
+    if (hasSeatIds) {
+      // Assigned seating: one cart_item per seat. Mark each inventory row as HELD.
+      if (!ticketType.event_id) {
+        res.status(400).json({ error: 'Ticket type sin evento' });
+        return;
+      }
+
+      const inventoryRows = await prisma.event_seat_inventory.findMany({
+        where: {
+          event_id: ticketType.event_id,
+          seat_id: { in: seatIds as string[] },
+          event_ticket_type_id: ticketTypeId,
+        },
+      });
+
+      if (inventoryRows.length !== seatIds.length) {
+        res.status(400).json({ error: 'Uno o más asientos no existen en el inventario del evento' });
+        return;
+      }
+
+      const unavailable = inventoryRows.filter((r) => r.status !== 'AVAILABLE');
+      if (unavailable.length > 0) {
+        res.status(409).json({ error: 'Uno o más asientos ya no están disponibles' });
+        return;
+      }
+
+      const created = await prisma.$transaction(
+        inventoryRows.flatMap((inv) => [
+          prisma.event_seat_inventory.update({
+            where: { id: inv.id },
+            data: { status: 'HELD' },
+          }),
+          prisma.cart_items.create({
+            data: {
+              cart_id: cart.id,
+              event_ticket_type_id: ticketTypeId,
+              event_seat_inventory_id: inv.id,
+              quantity: 1,
+              unit_price_amount: ticketType.price_amount,
+              service_fee_amount: ticketType.service_fee_amount,
+            },
+            include: cartItemIncludes,
+          }),
+        ])
+      );
+
+      // Return the last cart_item created (or all of them — frontend treats them individually)
+      const cartItems = created.filter((r: any) => r && r.cart_id);
+      const last = cartItems[cartItems.length - 1];
+      res.json(toCartItemDto(last));
+      return;
+    }
+
+    // General admission flow (unchanged)
+    if (!quantity || quantity < 1) {
+      res.status(400).json({ error: 'quantity es requerido para admisión general' });
+      return;
+    }
+
     const existing = await prisma.cart_items.findFirst({
-      where: { cart_id: cart.id, event_ticket_type_id: ticketTypeId },
+      where: { cart_id: cart.id, event_ticket_type_id: ticketTypeId, event_seat_inventory_id: null },
     });
 
     const item = existing
@@ -1295,19 +1329,32 @@ app.patch('/api/cart/items/:id', authMiddleware, async (req, res) => {
   }
 });
 
-// DELETE /api/cart/items/:id — remove single item
+// DELETE /api/cart/items/:id — remove single item (releases HELD inventory)
 app.delete('/api/cart/items/:id', authMiddleware, async (req, res) => {
   try {
     const userId = (req as any).userId;
-    const result = await prisma.cart_items.deleteMany({
+    const item = await prisma.cart_items.findFirst({
       where: {
         id: req.params.id as string,
         carts: { is: { user_id: userId, status: 'ACTIVE' } },
       },
+      select: { id: true, event_seat_inventory_id: true },
     });
-    if (result.count === 0) {
+    if (!item) {
       res.status(404).json({ error: 'Item de carrito no encontrado' });
       return;
+    }
+
+    if (item.event_seat_inventory_id) {
+      await prisma.$transaction([
+        prisma.event_seat_inventory.update({
+          where: { id: item.event_seat_inventory_id },
+          data: { status: 'AVAILABLE' },
+        }),
+        prisma.cart_items.delete({ where: { id: item.id } }),
+      ]);
+    } else {
+      await prisma.cart_items.delete({ where: { id: item.id } });
     }
     res.status(204).send();
   } catch (error: any) {
@@ -1316,13 +1363,30 @@ app.delete('/api/cart/items/:id', authMiddleware, async (req, res) => {
   }
 });
 
-// DELETE /api/cart/clear — remove all items from active cart
+// DELETE /api/cart/clear — remove all items from active cart (releases HELD inventory)
 app.delete('/api/cart/clear', authMiddleware, async (req, res) => {
   try {
     const userId = (req as any).userId;
-    const cart = await prisma.carts.findFirst({ where: { user_id: userId, status: 'ACTIVE' } });
+    const cart = await prisma.carts.findFirst({
+      where: { user_id: userId, status: 'ACTIVE' },
+      include: { cart_items: { select: { id: true, event_seat_inventory_id: true } } },
+    });
     if (cart) {
-      await prisma.cart_items.deleteMany({ where: { cart_id: cart.id } });
+      const heldInventoryIds = cart.cart_items
+        .map((i) => i.event_seat_inventory_id)
+        .filter((v): v is string => Boolean(v));
+
+      const ops: any[] = [];
+      if (heldInventoryIds.length > 0) {
+        ops.push(
+          prisma.event_seat_inventory.updateMany({
+            where: { id: { in: heldInventoryIds }, status: 'HELD' },
+            data: { status: 'AVAILABLE' },
+          })
+        );
+      }
+      ops.push(prisma.cart_items.deleteMany({ where: { cart_id: cart.id } }));
+      await prisma.$transaction(ops);
     }
     res.status(204).send();
   } catch (error: any) {
@@ -1395,6 +1459,7 @@ app.post('/api/checkout/confirm', authMiddleware, async (req, res) => {
 
     const orderItemCreates = cart.cart_items.map((cartItem) => ({
       event_ticket_type_id: cartItem.event_ticket_type_id,
+      event_seat_inventory_id: cartItem.event_seat_inventory_id,
       quantity: cartItem.quantity,
       unit_price_amount: cartItem.unit_price_amount,
       service_fee_amount: cartItem.service_fee_amount,
@@ -1407,9 +1472,13 @@ app.post('/api/checkout/confirm', authMiddleware, async (req, res) => {
       },
     }));
 
+    const seatInventoryIdsToSell = cart.cart_items
+      .map((i) => i.event_seat_inventory_id)
+      .filter((v): v is string => Boolean(v));
+
     // Use a batch transaction instead of an interactive tx callback. Supabase/pgBouncer
     // can drop long-lived interactive transactions in local/demo environments.
-    const [order] = await prisma.$transaction([
+    const ops: any[] = [
       prisma.orders.create({
         data: {
           user_id: userId,
@@ -1434,7 +1503,18 @@ app.post('/api/checkout/confirm', authMiddleware, async (req, res) => {
         },
       }),
       prisma.carts.update({ where: { id: cart.id }, data: { status: 'CONVERTED' } }),
-    ]);
+    ];
+
+    if (seatInventoryIdsToSell.length > 0) {
+      ops.push(
+        prisma.event_seat_inventory.updateMany({
+          where: { id: { in: seatInventoryIdsToSell } },
+          data: { status: 'SOLD' },
+        })
+      );
+    }
+
+    const [order] = await prisma.$transaction(ops);
 
     res.json({
       id: order.id,

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -157,6 +157,7 @@ function toEventDto(event: any) {
     city: event.venues?.cities?.city_name ?? null,
     organizer: event.organizers?.legal_name ?? '',
     venue: { name: event.venues?.name ?? '' },
+    venueType: event.venues?.venue_type ?? null,
     startsAt: event.starts_at,
     hasAssignedSeating: event.has_assigned_seating,
     minPrice: minPrice,
@@ -204,8 +205,12 @@ app.get('/api/events/featured', async (req, res) => {
 app.get('/api/events/:slug', async (req, res) => {
   try {
     const slug = req.params.slug;
+    const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(slug);
     const event = await cached(`events:slug:${slug}`, 30_000, () =>
-      prisma.events.findFirst({ where: { slug }, include: eventIncludes })
+      prisma.events.findFirst({
+        where: isUuid ? { OR: [{ id: slug }, { slug }] } : { slug },
+        include: eventIncludes,
+      })
     );
 
     if (!event) {
@@ -262,6 +267,104 @@ app.get('/api/events/:id/ticket-types', async (req, res) => {
   }
 });
 
+// GET /api/events/:id/seats - Sections + seats + availability for seat-map rendering
+app.get('/api/events/:id/seats', async (req, res) => {
+  try {
+    const eventId = req.params.id;
+
+    const event = await prisma.events.findUnique({
+      where: { id: eventId },
+      include: {
+        venues: true,
+        event_ticket_types: {
+          where: { is_active: true, venue_section_id: { not: null } },
+          select: {
+            id: true,
+            venue_section_id: true,
+            ticket_type_name: true,
+            price_amount: true,
+            service_fee_amount: true,
+            max_per_order: true,
+          },
+        },
+      },
+    });
+
+    if (!event) {
+      res.status(404).json({ error: 'Evento no encontrado' });
+      return;
+    }
+
+    if (!event.has_assigned_seating) {
+      res.status(400).json({ error: 'Este evento no tiene selección de asientos' });
+      return;
+    }
+
+    // Build a map: venue_section_id -> ticket_type
+    const ttBySectionId = new Map<string, any>();
+    for (const tt of event.event_ticket_types) {
+      if (tt.venue_section_id) ttBySectionId.set(tt.venue_section_id, tt);
+    }
+
+    // Get all venue sections for this venue (that have a ticket type for this event)
+    const sectionIds = [...ttBySectionId.keys()];
+    const sections = await prisma.venue_sections.findMany({
+      where: { id: { in: sectionIds } },
+      include: {
+        seats: {
+          where: { is_active: true },
+          orderBy: [{ row_label: 'asc' }, { seat_number: 'asc' }],
+        },
+      },
+      orderBy: { section_name: 'asc' },
+    });
+
+    // Get all inventory records for this event in these sections
+    const seatIds = sections.flatMap(s => s.seats.map(seat => seat.id));
+    const inventory = await prisma.event_seat_inventory.findMany({
+      where: { event_id: eventId, seat_id: { in: seatIds } },
+      select: { id: true, seat_id: true, status: true },
+    });
+    const inventoryBySeatId = new Map(inventory.map(inv => [inv.seat_id, inv]));
+
+    const sectionsDto = sections.map(section => {
+      const tt = ttBySectionId.get(section.id);
+      return {
+        id: section.id,
+        name: section.section_name,
+        code: section.section_code,
+        hasNumberedSeats: section.has_numbered_seats,
+        capacity: section.capacity,
+        ticketTypeId: tt?.id ?? null,
+        price: tt ? Number(tt.price_amount) : 0,
+        serviceFee: tt ? Number(tt.service_fee_amount) : 0,
+        maxPerOrder: tt?.max_per_order ?? 6,
+        seats: section.seats.map(seat => {
+          const inv = inventoryBySeatId.get(seat.id);
+          return {
+            inventoryId: inv?.id ?? null,
+            seatId: seat.id,
+            label: seat.seat_label,
+            row: seat.row_label ?? '',
+            number: seat.seat_number ?? 0,
+            isAccessible: seat.is_accessible,
+            status: inv?.status ?? 'AVAILABLE',
+          };
+        }),
+      };
+    });
+
+    res.json({
+      venueType: event.venues.venue_type,
+      venueName: event.venues.name,
+      sections: sectionsDto,
+    });
+  } catch (error: any) {
+    console.error(error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
 // GET /api/events/:id/related - Related events (same category)
 app.get('/api/events/:id/related', async (req, res) => {
   try {
@@ -279,6 +382,42 @@ app.get('/api/events/:id/related', async (req, res) => {
     res.json(result);
   } catch (error: any) {
     console.error(error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// GET /api/events/:id/occupied-seats — count of sold/active tickets per ticket_type
+app.get('/api/events/:id/occupied-seats', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const event = await prisma.events.findFirst({
+      where: { OR: [{ id }, { slug: id }] },
+      select: { id: true },
+    });
+    if (!event) { res.status(404).json({ error: 'Evento no encontrado' }); return; }
+
+    const ticketTypes = await prisma.event_ticket_types.findMany({
+      where: { event_id: event.id },
+      select: { id: true },
+    });
+
+    const occupancyMap: Record<string, number> = {};
+    await Promise.all(
+      ticketTypes.map(async (tt) => {
+        const count = await prisma.tickets.count({
+          where: {
+            status: { in: ['ACTIVE', 'USED'] },
+            order_item_id: { not: null },
+            order_items: { event_ticket_type_id: tt.id },
+          },
+        });
+        occupancyMap[tt.id] = count;
+      })
+    );
+
+    res.json(occupancyMap);
+  } catch (error: any) {
+    console.error('[SEATS] occupied-seats error:', error);
     res.status(500).json({ error: error.message });
   }
 });
@@ -1082,6 +1221,7 @@ async function getOrCreateCart(userId: string) {
 function toCartItemDto(item: any) {
   const tt = item.event_ticket_types;
   const evt = tt?.events;
+  const base = evt ? toEventDto(evt) : undefined;
   return {
     id: item.id,
     quantity: item.quantity,
@@ -1092,7 +1232,8 @@ function toCartItemDto(item: any) {
       price: Number(tt.price_amount),
       serviceFee: Number(tt.service_fee_amount),
     } : undefined,
-    event: evt ? toEventDto(evt) : undefined,
+    // venue must be a string for Cart.tsx (toEventDto returns an object)
+    event: base ? { ...base, venue: evt.venues?.name ?? '' } : undefined,
   };
 }
 
@@ -1136,16 +1277,28 @@ app.post('/api/cart/items', authMiddleware, async (req, res) => {
     }
 
     const cart = await getOrCreateCart(userId);
-    const item = await prisma.cart_items.create({
-      data: {
-        cart_id: cart.id,
-        event_ticket_type_id: ticketTypeId,
-        quantity,
-        unit_price_amount: ticketType.price_amount,
-        service_fee_amount: ticketType.service_fee_amount,
-      },
-      include: cartItemIncludes,
+
+    // If same ticket type already in cart, increment quantity instead of failing
+    const existing = await prisma.cart_items.findFirst({
+      where: { cart_id: cart.id, event_ticket_type_id: ticketTypeId },
     });
+
+    const item = existing
+      ? await prisma.cart_items.update({
+          where: { id: existing.id },
+          data: { quantity: existing.quantity + quantity },
+          include: cartItemIncludes,
+        })
+      : await prisma.cart_items.create({
+          data: {
+            cart_id: cart.id,
+            event_ticket_type_id: ticketTypeId,
+            quantity,
+            unit_price_amount: ticketType.price_amount,
+            service_fee_amount: ticketType.service_fee_amount,
+          },
+          include: cartItemIncludes,
+        });
 
     res.json(toCartItemDto(item));
   } catch (error: any) {

--- a/contracts/contracts/event_contract/src/lib.rs
+++ b/contracts/contracts/event_contract/src/lib.rs
@@ -542,6 +542,45 @@ impl ContratoEvento {
         let organizador = Self::obtener_organizador(&entorno)?;
         organizador.require_auth();
 
+        Self::crear_boleto_con_propietario(&entorno, id_evento, organizador, precio)
+    }
+
+    /*
+      Crea un nuevo boleto asignándolo directamente a una dirección concreta.
+      Este flujo se usa cuando el backend ya validó el checkout off-chain y el
+      organizador emite el boleto on-chain a la wallet vinculada del comprador.
+
+      Seguridad:
+      - Solo el organizador puede emitir el boleto.
+      - El propietario guardado en Soroban es el mismo que PostgreSQL debe
+        proyectar después de la confirmación.
+    */
+    pub fn crear_boleto_para(
+        entorno: Env,
+        id_evento: u32,
+        propietario: Address,
+        precio: i128,
+    ) -> Result<u32, ErrorContrato> {
+        if precio <= 0 {
+            return Err(ErrorContrato::PrecioInvalido);
+        }
+
+        let organizador = Self::obtener_organizador(&entorno)?;
+        organizador.require_auth();
+
+        Self::crear_boleto_con_propietario(&entorno, id_evento, propietario, precio)
+    }
+
+    fn crear_boleto_con_propietario(
+        entorno: &Env,
+        id_evento: u32,
+        propietario: Address,
+        precio: i128,
+    ) -> Result<u32, ErrorContrato> {
+        if precio <= 0 {
+            return Err(ErrorContrato::PrecioInvalido);
+        }
+
         // El contador funciona como auto-incremento: cada boleto nuevo
         // recibe el valor actual del contador como su ticket_root_id
         let mut contador_boletos: u32 = entorno
@@ -556,7 +595,7 @@ impl ContratoEvento {
             ticket_root_id,
             version,
             id_evento,
-            propietario: organizador.clone(),
+            propietario: propietario.clone(),
             precio,
             en_venta: false,
             es_reventa: false,
@@ -584,10 +623,10 @@ impl ContratoEvento {
         BoletoCreado {
             ticket_root_id,
             id_evento,
-            propietario: organizador,
+            propietario,
             precio,
         }
-        .publish(&entorno);
+        .publish(entorno);
 
         Ok(ticket_root_id)
     }

--- a/contracts/contracts/event_contract/src/test.rs
+++ b/contracts/contracts/event_contract/src/test.rs
@@ -186,6 +186,28 @@ fn test_create_ticket_success() {
     assert_eq!(boleto_2.id_evento, 1002);
 }
 
+// Crea un boleto asignado directamente a la wallet del comprador
+// Se espera que Soroban y la proyección off-chain puedan compartir el mismo owner
+#[test]
+fn test_create_ticket_for_owner_success() {
+    let (entorno, cliente, _admin, _organizador, _, _) = configurar_entorno();
+    let comprador = Address::generate(&entorno);
+
+    let root_id = cliente.crear_boleto_para(&1001, &comprador, &1_000_000);
+    assert_eq!(root_id, 0);
+
+    let boleto = cliente.obtener_boleto(&root_id);
+    assert_eq!(boleto.ticket_root_id, root_id);
+    assert_eq!(boleto.version, 0);
+    assert_eq!(boleto.id_evento, 1001);
+    assert_eq!(boleto.precio, 1_000_000);
+    assert_eq!(boleto.propietario, comprador);
+    assert!(!boleto.en_venta);
+    assert!(!boleto.es_reventa);
+    assert!(!boleto.usado);
+    assert!(!boleto.invalidado);
+}
+
 // Intenta crear un boleto con precio negativo
 // Se espera error PrecioInvalido
 #[test]

--- a/contracts/contracts/event_contract/test_snapshots/test/test_create_ticket_for_owner_success.1.json
+++ b/contracts/contracts/event_contract/test_snapshots/test/test_create_ticket_for_owner_success.1.json
@@ -1,0 +1,570 @@
+{
+  "generators": {
+    "address": 6,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+              "function_name": "set_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "inicializar",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG"
+                },
+                {
+                  "i128": "20"
+                },
+                {
+                  "i128": "10"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "crear_boleto_para",
+              "args": [
+                {
+                  "u32": 1001
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "i128": "1000000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "account": {
+            "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "account": {
+                "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV",
+                "balance": "0",
+                "seq_num": "0",
+                "num_sub_entries": 0,
+                "inflation_dest": null,
+                "flags": 0,
+                "home_domain": "",
+                "thresholds": "01010101",
+                "signers": [],
+                "ext": "v0"
+              }
+            },
+            "ext": "v0"
+          },
+          null
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "1033654523790656264"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Boleto"
+                            },
+                            {
+                              "u32": 0
+                            },
+                            {
+                              "u32": 0
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "en_venta"
+                              },
+                              "val": {
+                                "bool": false
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "es_reventa"
+                              },
+                              "val": {
+                                "bool": false
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "id_evento"
+                              },
+                              "val": {
+                                "u32": 1001
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "invalidado"
+                              },
+                              "val": {
+                                "bool": false
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "precio"
+                              },
+                              "val": {
+                                "i128": "1000000"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "propietario"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "ticket_root_id"
+                              },
+                              "val": {
+                                "u32": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "usado"
+                              },
+                              "val": {
+                                "bool": false
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "version"
+                              },
+                              "val": {
+                                "u32": 0
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ComisionOrganizador"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": "20"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ComisionPlataforma"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": "10"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ContadorBoletos"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Organizador"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Plataforma"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TokenPago"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "VersionActual"
+                            },
+                            {
+                              "u32": 0
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 0
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": "stellar_asset",
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "METADATA"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "decimal"
+                              },
+                              "val": {
+                                "u32": 7
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "name"
+                              },
+                              "val": {
+                                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "symbol"
+                              },
+                              "val": {
+                                "string": "aaa"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AssetInfo"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "AlphaNum4"
+                            },
+                            {
+                              "map": [
+                                {
+                                  "key": {
+                                    "symbol": "asset_code"
+                                  },
+                                  "val": {
+                                    "string": "aaa\\0"
+                                  }
+                                },
+                                {
+                                  "key": {
+                                    "symbol": "issuer"
+                                  },
+                                  "val": {
+                                    "bytes": "0000000000000000000000000000000000000000000000000000000000000005"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          120960
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ Documentación de arquitectura, modelo de datos, eventos y referencias técnicas
 ### `operations/`
 Documentación operativa del proyecto.
 - `operations/DEVELOPMENT_WORKFLOW.md`
+- `operations/ENVIRONMENTS.md`
 - `operations/TESTNET_DEPLOYMENTS.md`
 - `operations/WALLETS_ROLES_TESTNET.md`
 
@@ -62,7 +63,8 @@ Este archivo se mantiene temporalmente en la raíz de `docs/` hasta decidir si r
 3. `audits/CONTRACTS_AUDIT.md`
 4. `audits/FRONTEND_AUDIT.md`
 5. `operations/DEVELOPMENT_WORKFLOW.md`
-6. `setup/DOCKER_CLI_WORKFLOW.md`
+6. `operations/ENVIRONMENTS.md`
+7. `setup/DOCKER_CLI_WORKFLOW.md`
 
 ## Nota
 

--- a/docs/operations/DEVELOPMENT_WORKFLOW.md
+++ b/docs/operations/DEVELOPMENT_WORKFLOW.md
@@ -6,27 +6,28 @@ Definir una forma consistente de trabajar en el repositorio para mantener trazab
 
 ---
 
-## Rama principal
+## Ramas Principales
 
-- `main`: rama estable del proyecto
+- `develop`: rama de integracion y pruebas; alimenta el ambiente `staging`.
+- `main`: rama estable del proyecto; alimenta el ambiente demo / produccion academica.
 
-La rama `main` debe mantenerse en un estado presentable y coherente.
+La rama `main` debe mantenerse en un estado presentable y coherente. La rama `develop` puede recibir cambios validados por Pull Request para probarlos en staging antes de promoverlos.
 
-No se debe trabajar directamente sobre `main`.
+No se debe trabajar directamente sobre `develop` ni sobre `main`.
 
 ---
 
-## Ramas de trabajo
+## Ramas De Trabajo
 
-Cada cambio importante debe realizarse en una rama separada.
+Cada cambio importante debe realizarse en una rama separada creada desde `develop`.
 
 ### Convenciones
 
 - `fix/...` para correcciones
 - `feat/...` para nuevas funcionalidades
-- `docs/...` para documentación
+- `docs/...` para documentacion
 - `chore/...` para mantenimiento o limpieza
-- `refactor/...` para reorganización interna sin cambiar comportamiento
+- `refactor/...` para reorganizacion interna sin cambiar comportamiento
 
 ### Ejemplos
 
@@ -38,22 +39,41 @@ Cada cambio importante debe realizarse en una rama separada.
 
 ---
 
-## Flujo de trabajo
+## Flujo De Trabajo
 
 ### Proceso recomendado
 
-1. Identificar el problema o tarea
-2. Crear un issue o dejar definida la tarea
-3. Crear una rama desde `main`
-4. Implementar el cambio
-5. Hacer commits claros y pequeños
-6. Subir la rama a GitHub
-7. Abrir Pull Request
-8. Revisar y hacer merge
+1. Identificar el problema o tarea.
+2. Crear un issue o dejar definida la tarea.
+3. Crear una rama desde `develop`.
+4. Implementar el cambio.
+5. Hacer commits claros y pequeños.
+6. Subir la rama a GitHub.
+7. Abrir Pull Request hacia `develop`.
+8. Revisar y hacer merge.
+9. Probar el cambio en staging.
+10. Si staging pasa, abrir Pull Request de `develop` hacia `main`.
+11. Hacer merge a `main` para promover a demo / produccion academica.
 
 ### Ejemplo
 
 ```bash
-git checkout main
+git checkout develop
 git pull
 git checkout -b fix/cart-idor
+```
+
+## Promocion A Demo
+
+Cuando staging funciona correctamente, se promueve `develop` hacia `main` mediante Pull Request.
+
+```bash
+git checkout develop
+git pull
+git checkout main
+git pull
+```
+
+Luego se abre un Pull Request de `develop` hacia `main`.
+
+El merge a `main` representa la version estable que puede desplegarse en el ambiente demo / produccion academica.

--- a/docs/operations/ENVIRONMENTS.md
+++ b/docs/operations/ENVIRONMENTS.md
@@ -1,0 +1,123 @@
+# Environments
+
+## Objetivo
+
+Definir como se separan los ambientes del proyecto para probar cambios sin afectar la demo estable.
+
+## Regla principal
+
+- `develop` alimenta el ambiente de pruebas (`staging`).
+- `main` alimenta el ambiente estable de demo / produccion academica.
+- No se trabaja directo sobre `develop` ni sobre `main`; los cambios entran por Pull Request.
+
+## Ambientes
+
+### Staging
+
+Ambiente para probar y romper cosas antes de promover cambios.
+
+- Rama fuente: `develop`
+- Backend: Railway `backend-staging`
+- Frontend: Vercel `frontend-staging`
+- Base de datos: `db-staging`
+- Wallets: cuentas Stellar testnet dedicadas a staging
+- Contratos: contratos testnet dedicados a staging cuando aplique
+
+Variables backend:
+
+```env
+NODE_ENV=production
+DATABASE_URL=<staging database url>
+JWT_SECRET=<staging jwt secret>
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+ORGANIZER_SECRET=<staging organizer secret>
+ORGANIZER_PUBLIC=<staging organizer public key>
+```
+
+Variables frontend:
+
+```env
+VITE_API_BASE_URL=https://<backend-staging-url>
+```
+
+### Demo / Produccion Academica
+
+Ambiente estable para presentar el proyecto.
+
+- Rama fuente: `main`
+- Backend: Railway `backend-demo`
+- Frontend: Vercel `frontend-demo`
+- Base de datos: `db-demo`
+- Wallets: cuentas Stellar testnet dedicadas a demo
+- Contratos: contratos testnet documentados para demo
+
+Variables backend:
+
+```env
+NODE_ENV=production
+DATABASE_URL=<demo database url>
+JWT_SECRET=<demo jwt secret>
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+ORGANIZER_SECRET=<demo organizer secret>
+ORGANIZER_PUBLIC=<demo organizer public key>
+```
+
+Variables frontend:
+
+```env
+VITE_API_BASE_URL=https://<backend-demo-url>
+```
+
+## Flujo de Cambios
+
+1. Crear una rama de trabajo desde `develop`.
+2. Implementar el cambio.
+3. Abrir Pull Request hacia `develop`.
+4. Al hacer merge, se despliega staging.
+5. Probar el flujo afectado en staging.
+6. Si staging esta correcto, abrir Pull Request de `develop` hacia `main`.
+7. Al hacer merge a `main`, se despliega la demo / produccion academica.
+
+## Configuracion En Monorepo
+
+El repositorio es un monorepo. Cada servicio debe apuntar a su carpeta raiz.
+
+Backend Railway:
+
+```text
+Root Directory: backend
+Build Command: npm install && npm run build
+Start Command: npm start
+```
+
+Frontend Vercel:
+
+```text
+Root Directory: frontend
+Framework Preset: Vite
+Build Command: npm run build
+Output Directory: dist
+```
+
+## Smoke Tests De Staging
+
+Antes de promover a `main`, validar:
+
+- `GET /health` responde correctamente en backend staging.
+- El frontend staging carga sin 404.
+- El frontend staging usa `VITE_API_BASE_URL` de backend staging, no `localhost`.
+- Registro/login funciona.
+- Catalogo y detalle de evento cargan.
+- Carrito funciona.
+- Checkout funciona.
+- Mis entradas funciona.
+- Flujos blockchain se prueban con wallets staging.
+- Scanner se prueba contra datos staging.
+
+## Reglas De Cuidado
+
+- No usar la base de datos demo para pruebas.
+- No usar wallets demo para pruebas.
+- No guardar secrets en el repositorio.
+- No promover a `main` si staging no paso smoke test.
+- Documentar direcciones de contratos demo en `docs/operations/TESTNET_DEPLOYMENTS.md`.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:," />
+    <link rel="apple-touch-icon" href="data:," />
     <title>TuTicket</title>
     <meta name="description" content="Aplicacion web de TuTicket" />
     <meta name="author" content="TuTicket" />

--- a/frontend/src/components/ConnectWallet.tsx
+++ b/frontend/src/components/ConnectWallet.tsx
@@ -13,10 +13,10 @@ const isSafariBrowser = () =>
   /^((?!chrome|android|crios|fxios|edgios).)*safari/i.test(navigator.userAgent);
 
 export const ConnectWallet = () => {
-  const [address, setAddress] = useState<string | null>(null);
+  const { walletAddress, setWalletAddress, linkWallet, isLoggedIn, balanceVersion } = useAppContext();
+  const address = walletAddress;
   const [balance, setBalance] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const { setWalletAddress, linkWallet, isLoggedIn, balanceVersion } = useAppContext();
+  const [loading, setLoading] = useState(!walletAddress);
   const xlmCop = useXlmPrice();
 
   const fetchBalance = async (pk: string) => {
@@ -46,17 +46,20 @@ export const ConnectWallet = () => {
     }
   };
 
-  // Refresh balance when balanceVersion changes (after buy/list/cancel)
+  // Refresh balance when balanceVersion changes (after buy/list/cancel) or address loads
   useEffect(() => {
-    if (address && balanceVersion > 0) fetchBalance(address);
-  }, [balanceVersion]); // eslint-disable-line react-hooks/exhaustive-deps
+    if (address) fetchBalance(address);
+  }, [balanceVersion, address]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Only auto-detect wallet when user is logged in
+  // Auto-detect Freighter only if logged in AND no address cached in context yet.
   useEffect(() => {
     if (!isLoggedIn) {
-      setAddress(null);
       setBalance(null);
       setWalletAddress(null);
+      setLoading(false);
+      return;
+    }
+    if (address) {
       setLoading(false);
       return;
     }
@@ -72,9 +75,7 @@ export const ConnectWallet = () => {
         if (pk) {
           const linked = await tryLinkWallet(pk);
           if (linked) {
-            setAddress(pk);
             setWalletAddress(pk);
-            fetchBalance(pk);
           }
         }
       } catch (error) {
@@ -84,7 +85,7 @@ export const ConnectWallet = () => {
       }
     };
     checkConnection();
-  }, [setWalletAddress, linkWallet, isLoggedIn]);
+  }, [setWalletAddress, linkWallet, isLoggedIn, address]);
 
   const connectWallet = async () => {
     if (!isLoggedIn) {
@@ -107,9 +108,7 @@ export const ConnectWallet = () => {
       if (pk) {
         const linked = await tryLinkWallet(pk);
         if (linked) {
-          setAddress(pk);
           setWalletAddress(pk);
-          fetchBalance(pk);
         }
       } else {
         alert("Freighter no devolvió una dirección. Desbloquea la extensión, permite el sitio y vuelve a intentar.");

--- a/frontend/src/components/ConnectWallet.tsx
+++ b/frontend/src/components/ConnectWallet.tsx
@@ -7,6 +7,10 @@ import { useXlmPrice, formatCOP } from "@/hooks/useXlmPrice";
 const freighterApi = () => import("@stellar/freighter-api");
 
 const HORIZON_URL = "https://horizon-testnet.stellar.org";
+const isFreighterInjected = () => typeof window !== "undefined" && Boolean((window as any).freighter);
+const isSafariBrowser = () =>
+  typeof navigator !== "undefined" &&
+  /^((?!chrome|android|crios|fxios|edgios).)*safari/i.test(navigator.userAgent);
 
 export const ConnectWallet = () => {
   const [address, setAddress] = useState<string | null>(null);
@@ -58,10 +62,8 @@ export const ConnectWallet = () => {
     }
     const checkConnection = async () => {
       try {
+        if (!isFreighterInjected()) return;
         const api = await freighterApi();
-        const connResult = await api.isConnected();
-        const conn = (connResult as any)?.isConnected ?? connResult;
-        if (!conn) return;
         const allowResult = await api.isAllowed();
         const allowed = (allowResult as any)?.isAllowed ?? allowResult;
         if (!allowed) return;
@@ -90,15 +92,17 @@ export const ConnectWallet = () => {
       return;
     }
     try {
-      const api = await freighterApi();
-      const connResult = await api.isConnected();
-      const conn = (connResult as any)?.isConnected ?? connResult;
-      if (!conn) {
-        alert("¡Por favor instala la extensión de Freighter en tu navegador!");
+      if (isSafariBrowser() && !isFreighterInjected()) {
+        alert("No detecté Freighter en Safari. Para esta demo usa Chrome o Brave con la extensión Freighter instalada y desbloqueada.");
         window.open("https://freighter.app", "_blank");
         return;
       }
+      const api = await freighterApi();
       const accessResult = await api.requestAccess();
+      if ((accessResult as any)?.error) {
+        alert((accessResult as any).error.message ?? "Freighter no permitió conectar la billetera.");
+        return;
+      }
       const pk = (accessResult as any)?.address ?? (typeof accessResult === "string" ? accessResult : "");
       if (pk) {
         const linked = await tryLinkWallet(pk);
@@ -107,9 +111,12 @@ export const ConnectWallet = () => {
           setWalletAddress(pk);
           fetchBalance(pk);
         }
+      } else {
+        alert("Freighter no devolvió una dirección. Desbloquea la extensión, permite el sitio y vuelve a intentar.");
       }
     } catch (error) {
       console.error("Error connecting wallet:", error);
+      alert("No fue posible conectar Freighter. Verifica que la extensión esté instalada, desbloqueada y con permisos para localhost; luego recarga la página.");
     }
   };
 

--- a/frontend/src/components/ui/SeatMap.tsx
+++ b/frontend/src/components/ui/SeatMap.tsx
@@ -1,128 +1,626 @@
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 
-export interface Seat {
+// ── Public types ───────────────────────────────────────────────────────────
+
+export type VenueType =
+  | "STADIUM" | "THEATER" | "ARENA"
+  | "CLUB" | "COLISEUM" | "CONVENTION_CENTER";
+
+export interface SectionConfig {
   id: string;
-  section: string;
+  name: string;
+  price: number;
+  serviceFee: number;
+  capacity: number;
+  maxPerOrder: number;
+}
+
+export interface SelectedSeat {
+  id: string;
   row: string;
   number: number;
-  status: "available" | "occupied" | "disabled";
+  label: string;
+  sectionId: string;
+  sectionName: string;
+  ticketTypeId: string;
   price: number;
   serviceFee: number;
 }
 
+export type Seat = SelectedSeat;
+
 interface SeatMapProps {
-  eventId: string;
-  selectedSeats: Seat[];
-  onToggleSeat: (seat: Seat) => void;
+  venueType: VenueType;
+  venueName: string;
+  sections: SectionConfig[];
+  selectedSeats: SelectedSeat[];
+  onToggleSeat: (seat: SelectedSeat) => void;
+  maxSeats?: number;
+  /** sold/active ticket count per sectionId (ticket_type id) */
+  occupancyPerSection?: Record<string, number>;
 }
 
-const SECTIONS = [
-  { name: "VIP", rows: 2, cols: 10, price: 450000, fee: 36000, color: "bg-amber-400" },
-  { name: "Platea", rows: 3, cols: 12, price: 280000, fee: 22400, color: "bg-primary" },
-  { name: "General", rows: 4, cols: 14, price: 120000, fee: 9600, color: "bg-emerald-500" },
+// ── Palette ────────────────────────────────────────────────────────────────
+
+const PALETTE = [
+  { available: "#7c3aed", label: "bg-violet-100 text-violet-800 border-violet-300" },
+  { available: "#0284c7", label: "bg-sky-100 text-sky-800 border-sky-300" },
+  { available: "#059669", label: "bg-emerald-100 text-emerald-800 border-emerald-300" },
+  { available: "#d97706", label: "bg-amber-100 text-amber-800 border-amber-300" },
+  { available: "#e11d48", label: "bg-rose-100 text-rose-800 border-rose-300" },
 ];
 
-function seededRandom(seed: number) {
-  let x = Math.sin(seed) * 10000;
-  return x - Math.floor(x);
+function hexAlpha(hex: string, alpha: number): string {
+  return hex + Math.round(alpha * 255).toString(16).padStart(2, "0");
 }
 
-export const SeatMap = ({ eventId, selectedSeats, onToggleSeat }: SeatMapProps) => {
-  const seats = useMemo(() => {
-    const all: Seat[] = [];
-    let seedBase = 0;
-    for (let i = 0; i < eventId.length; i++) seedBase += eventId.charCodeAt(i);
+// ── Row type ───────────────────────────────────────────────────────────────
 
-    SECTIONS.forEach((section) => {
-      for (let r = 0; r < section.rows; r++) {
-        const rowLabel = String.fromCharCode(65 + r);
-        for (let c = 1; c <= section.cols; c++) {
-          const rnd = seededRandom(seedBase + r * 100 + c);
-          const status: Seat["status"] =
-            rnd < 0.2 ? "occupied" : rnd < 0.05 ? "disabled" : "available";
-          all.push({
-            id: `${section.name}-${rowLabel}${c}`,
-            section: section.name,
-            row: rowLabel,
-            number: c,
-            status,
-            price: section.price,
-            serviceFee: section.fee,
-          });
-        }
-      }
-    });
-    return all;
-  }, [eventId]);
+interface MapRow {
+  label: string;
+  seats: { id: string; row: string; number: number }[];
+  sectionId: string;
+  sectionIndex: number;
+  isFirstRow: boolean;
+}
 
-  const isSelected = (seatId: string) => selectedSeats.some((s) => s.id === seatId);
+// ── Build rows for a section ───────────────────────────────────────────────
+
+function buildRows(section: SectionConfig, sectionIndex: number, colCount: number, maxRows: number): MapRow[] {
+  const cap = Math.min(section.capacity, colCount * maxRows);
+  const numRows = Math.min(maxRows, Math.ceil(cap / colCount));
+  const rows: MapRow[] = [];
+  let remaining = cap;
+  for (let r = 0; r < numRows; r++) {
+    const label = String.fromCharCode(65 + r);
+    const n = Math.min(colCount, remaining);
+    const seats = Array.from({ length: n }, (_, c) => ({
+      id: `${section.id}-${label}${c + 1}`,
+      row: label,
+      number: c + 1,
+    }));
+    rows.push({ label, seats, sectionId: section.id, sectionIndex, isFirstRow: r === 0 });
+    remaining -= n;
+  }
+  return rows;
+}
+
+// ── Build occupied set from real occupancy counts ──────────────────────────
+// Marks the first N seat IDs (in row order) as occupied for each section.
+
+function buildOccupiedFromRows(rows: MapRow[], occupancyPerSection: Record<string, number>): Set<string> {
+  const occupied = new Set<string>();
+  const added: Record<string, number> = {};
+  for (const row of rows) {
+    const quota = occupancyPerSection[row.sectionId] ?? 0;
+    for (const seat of row.seats) {
+      if ((added[row.sectionId] ?? 0) >= quota) break;
+      occupied.add(seat.id);
+      added[row.sectionId] = (added[row.sectionId] ?? 0) + 1;
+    }
+  }
+  return occupied;
+}
+
+// ── Shared seat button ─────────────────────────────────────────────────────
+
+interface SeatBtnProps {
+  seat: { id: string; row: string; number: number };
+  sectionId: string;
+  sectionIndex: number;
+  sectionMap: Record<string, SectionConfig>;
+  selectedIds: Set<string>;
+  occupiedIds: Set<string>;
+  maxReached: boolean;
+  onToggle: (seat: SelectedSeat) => void;
+  size?: "sm" | "xs";
+}
+
+function SeatBtn({ seat, sectionId, sectionIndex, sectionMap, selectedIds, occupiedIds, maxReached, onToggle, size = "sm" }: SeatBtnProps) {
+  const isSel = selectedIds.has(seat.id);
+  const isOcc = occupiedIds.has(seat.id);
+  const isBlocked = !isSel && !isOcc && maxReached;
+  const disabled = isOcc || isBlocked;
+  const p = PALETTE[sectionIndex % PALETTE.length];
+  const section = sectionMap[sectionId];
+  const dim = size === "xs" ? "w-5 h-5 text-[7px]" : "w-6 h-6 text-[8px]";
+
+  let bgStyle: React.CSSProperties = {};
+  let extraClass = "";
+
+  if (isSel) {
+    bgStyle = {
+      backgroundColor: p.available,
+      color: "white",
+      boxShadow: `0 0 0 2px white, 0 0 0 3.5px ${p.available}`,
+    };
+    extraClass = "scale-110 cursor-pointer";
+  } else if (isOcc) {
+    extraClass = "bg-muted-foreground/20 text-transparent cursor-not-allowed";
+  } else if (isBlocked) {
+    extraClass = "bg-muted/60 text-transparent cursor-not-allowed opacity-50";
+  } else {
+    bgStyle = {
+      backgroundColor: hexAlpha(p.available, 0.15),
+      color: p.available,
+    };
+    extraClass = "hover:scale-105 active:scale-95 cursor-pointer";
+  }
 
   return (
-    <div className="space-y-6">
-      {/* Stage */}
-      <div className="mx-auto w-3/4 py-3 bg-muted rounded-t-[100%] text-center">
-        <span className="text-xs font-bold text-muted-foreground uppercase tracking-widest">Escenario</span>
-      </div>
+    <button
+      disabled={disabled}
+      onClick={() => {
+        if (!section || disabled) return;
+        onToggle({
+          id: seat.id,
+          row: seat.row,
+          number: seat.number,
+          label: `${section.name} ${seat.row}${seat.number}`,
+          sectionId: section.id,
+          sectionName: section.name,
+          ticketTypeId: section.id,
+          price: section.price,
+          serviceFee: section.serviceFee,
+        });
+      }}
+      title={isOcc ? "Asiento ocupado" : `${seat.row}${seat.number} · ${section?.name} · $${section?.price.toLocaleString("es-CO")}`}
+      style={bgStyle}
+      className={`${dim} rounded-sm font-bold flex items-center justify-center transition-transform select-none border-0 outline-none shrink-0 ${extraClass}`}
+    >
+      {isSel ? "✓" : isOcc ? "" : seat.number}
+    </button>
+  );
+}
 
-      {/* Sections */}
-      {SECTIONS.map((section) => {
-        const sectionSeats = seats.filter((s) => s.section === section.name);
-        const rows = [...new Set(sectionSeats.map((s) => s.row))];
-        return (
-          <div key={section.name} className="space-y-1">
-            <div className="flex items-center gap-2 mb-1">
-              <div className={`w-3 h-3 rounded-sm ${section.color}`} />
-              <span className="text-xs font-bold text-foreground">{section.name}</span>
-              <span className="text-xs text-muted-foreground">— ${section.price.toLocaleString("es-CO")}</span>
-            </div>
-            {rows.map((row) => (
-              <div key={row} className="flex items-center justify-center gap-1">
-                <span className="w-5 text-[10px] text-muted-foreground font-bold text-right">{row}</span>
-                {sectionSeats
-                  .filter((s) => s.row === row)
-                  .map((seat) => {
-                    const sel = isSelected(seat.id);
-                    const occupied = seat.status === "occupied";
-                    const disabled = seat.status === "disabled";
-                    return (
-                      <button
-                        key={seat.id}
-                        disabled={occupied || disabled}
-                        onClick={() => onToggleSeat(seat)}
-                        title={`${seat.id} - $${seat.price.toLocaleString("es-CO")}`}
-                        className={`w-6 h-6 md:w-7 md:h-7 rounded-sm text-[9px] font-bold transition-all ${
-                          sel
-                            ? "bg-accent text-accent-foreground ring-2 ring-accent scale-110"
-                            : occupied
-                            ? "bg-muted-foreground/30 text-transparent cursor-not-allowed"
-                            : disabled
-                            ? "bg-muted text-transparent cursor-not-allowed"
-                            : `${section.color}/20 text-foreground/60 hover:${section.color}/50 hover:scale-105 cursor-pointer`
-                        }`}
-                      >
-                        {seat.number}
-                      </button>
-                    );
-                  })}
-              </div>
+// ── Section badge (stadium headers) ───────────────────────────────────────
+
+function SectionBadge({ name, pi }: { name: string; pi: number }) {
+  const p = PALETTE[pi % PALETTE.length];
+  return (
+    <span className={`text-[10px] font-black uppercase tracking-wider px-2 py-0.5 rounded-full border ${p.label}`}>
+      {name}
+    </span>
+  );
+}
+
+// ── Section header (cinema sections) ──────────────────────────────────────
+
+function SectionHeader({ section, pi }: { section: SectionConfig; pi: number }) {
+  const p = PALETTE[pi % PALETTE.length];
+  return (
+    <div className="flex items-center gap-2 mt-4 mb-2 px-1">
+      <div className="w-3 h-3 rounded-sm" style={{ backgroundColor: p.available }} />
+      <span className="text-xs font-bold text-foreground">{section.name}</span>
+      <span className="text-xs text-muted-foreground">— ${section.price.toLocaleString("es-CO")}</span>
+    </div>
+  );
+}
+
+// ── Horizontal rows (Norte / Sur / cinema) ─────────────────────────────────
+
+interface HorizRowsProps {
+  rows: MapRow[];
+  cols: number;
+  sectionMap: Record<string, SectionConfig>;
+  selectedIds: Set<string>;
+  occupiedIds: Set<string>;
+  maxReached: boolean;
+  onToggle: (seat: SelectedSeat) => void;
+}
+
+function HorizRows({ rows, cols, sectionMap, selectedIds, occupiedIds, maxReached, onToggle }: HorizRowsProps) {
+  return (
+    <div className="space-y-[3px]">
+      {rows.map((row) => (
+        <div key={`${row.sectionId}-${row.label}`} className="flex items-center gap-1">
+          <span className="w-4 shrink-0 text-[9px] font-bold text-muted-foreground text-right select-none">{row.label}</span>
+          <div className="flex gap-[3px]">
+            {row.seats.map((seat) => (
+              <SeatBtn key={seat.id} seat={seat} sectionId={row.sectionId} sectionIndex={row.sectionIndex}
+                sectionMap={sectionMap} selectedIds={selectedIds} occupiedIds={occupiedIds} maxReached={maxReached} onToggle={onToggle} />
+            ))}
+            {Array.from({ length: cols - row.seats.length }).map((_, i) => (
+              <div key={`pad${i}`} className="w-6 h-6 shrink-0" />
             ))}
           </div>
-        );
-      })}
+          <span className="w-4 shrink-0 text-[9px] font-bold text-muted-foreground select-none">{row.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
 
-      {/* Legend */}
-      <div className="flex flex-wrap items-center justify-center gap-4 pt-4 border-t border-border">
-        {[
-          { label: "Disponible", cls: "bg-primary/20 border border-primary/30" },
-          { label: "Seleccionado", cls: "bg-accent" },
-          { label: "Ocupado", cls: "bg-muted-foreground/30" },
-        ].map(({ label, cls }) => (
-          <div key={label} className="flex items-center gap-1.5">
-            <div className={`w-5 h-5 rounded-sm ${cls}`} />
-            <span className="text-xs text-muted-foreground">{label}</span>
-          </div>
-        ))}
+// ── Vertical columns (Occidental / Oriental) ───────────────────────────────
+
+interface VertColsProps {
+  rows: MapRow[];
+  reversed: boolean;
+  sectionMap: Record<string, SectionConfig>;
+  selectedIds: Set<string>;
+  occupiedIds: Set<string>;
+  maxReached: boolean;
+  onToggle: (seat: SelectedSeat) => void;
+}
+
+function VertCols({ rows, reversed, sectionMap, selectedIds, occupiedIds, maxReached, onToggle }: VertColsProps) {
+  const display = reversed ? [...rows].reverse() : rows;
+  return (
+    <div className="flex gap-[3px]">
+      {display.map((row) => (
+        <div key={`${row.sectionId}-${row.label}`} className="flex flex-col gap-[3px]">
+          {row.seats.map((seat) => (
+            <SeatBtn key={seat.id} seat={seat} sectionId={row.sectionId} sectionIndex={row.sectionIndex}
+              sectionMap={sectionMap} selectedIds={selectedIds} occupiedIds={occupiedIds} maxReached={maxReached} onToggle={onToggle} size="xs" />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Oval field ─────────────────────────────────────────────────────────────
+
+function OvalField() {
+  return (
+    <div
+      className="flex items-center justify-center shrink-0"
+      style={{
+        background: "linear-gradient(160deg, #14532d 0%, #166534 50%, #15803d 100%)",
+        borderRadius: "50%",
+        width: 200,
+        height: 120,
+        border: "3px solid #22c55e",
+        boxShadow: "0 0 28px rgba(34,197,94,0.30), inset 0 0 20px rgba(0,0,0,0.35)",
+      }}
+    >
+      <div
+        style={{
+          border: "1.5px solid rgba(255,255,255,0.22)",
+          borderRadius: "50%",
+          width: 130,
+          height: 76,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <span className="text-green-300/60 text-[9px] font-black tracking-widest uppercase">Cancha</span>
       </div>
     </div>
   );
-};
+}
+
+// ── Stage visual ───────────────────────────────────────────────────────────
+
+function Stage({ venueType }: { venueType: VenueType }) {
+  const isTheater = venueType === "THEATER";
+  return (
+    <div className="flex flex-col items-center mb-8">
+      <div
+        className={`w-3/4 py-3 text-center rounded-t-[100%] ${isTheater ? "" : "bg-muted"}`}
+        style={isTheater ? { background: "linear-gradient(135deg, #92400e, #b45309, #92400e)" } : undefined}
+      >
+        <span className={`text-xs font-bold uppercase tracking-widest ${isTheater ? "text-amber-100" : "text-muted-foreground"}`}>
+          Escenario
+        </span>
+      </div>
+      <div className="w-3/4 h-3 bg-gradient-to-b from-muted/30 to-transparent" />
+    </div>
+  );
+}
+
+// ── Stadium position detector ──────────────────────────────────────────────
+
+type StadiumPos = "norte" | "sur" | "occidental" | "oriental" | "extra";
+
+function getStadiumPos(name: string, index: number): StadiumPos {
+  const n = name.toLowerCase();
+  if (n.includes("norte") || n.includes("north")) return "norte";
+  if (n.includes("sur") || n.includes("south")) return "sur";
+  if (n.includes("occid") || n.includes("oeste") || n.includes("west")) return "occidental";
+  if (n.includes("orient") || n.includes("este") || n.includes("east")) return "oriental";
+  if (n.includes("palco")) return "norte";
+  if (n === "vip") return "sur";
+  const fallback: StadiumPos[] = ["norte", "sur", "occidental", "oriental", "extra"];
+  return fallback[index % fallback.length];
+}
+
+// ── Stadium layout ─────────────────────────────────────────────────────────
+
+const HORIZ_COLS = 14;
+const HORIZ_MAX_ROWS = 10;
+const VERT_SEATS = 10;
+const VERT_MAX_COLS = 8;
+
+interface StadiumLayoutProps {
+  sections: SectionConfig[];
+  selectedSeats: SelectedSeat[];
+  onToggleSeat: (seat: SelectedSeat) => void;
+  maxSeats: number;
+  occupancyPerSection: Record<string, number>;
+}
+
+function StadiumLayout({ sections, selectedSeats, onToggleSeat, maxSeats, occupancyPerSection }: StadiumLayoutProps) {
+  const maxReached = selectedSeats.length >= maxSeats;
+  const selectedIds = useMemo(() => new Set(selectedSeats.map((s) => s.id)), [selectedSeats]);
+  const sectionMap = useMemo(() => {
+    const m: Record<string, SectionConfig> = {};
+    for (const s of sections) m[s.id] = s;
+    return m;
+  }, [sections]);
+
+  const positioned = useMemo(() => {
+    const r: Record<StadiumPos, Array<{ section: SectionConfig; rows: MapRow[]; pi: number }>> = {
+      norte: [], sur: [], occidental: [], oriental: [], extra: [],
+    };
+    sections.forEach((s, i) => {
+      const pos = getStadiumPos(s.name, i);
+      const isVert = pos === "occidental" || pos === "oriental";
+      const rows = buildRows(s, i, isVert ? VERT_SEATS : HORIZ_COLS, isVert ? VERT_MAX_COLS : HORIZ_MAX_ROWS);
+      r[pos].push({ section: s, rows, pi: i });
+    });
+    return r;
+  }, [sections]);
+
+  // Build occupied set from all rows across all positions
+  const occupiedIds = useMemo(() => {
+    const allRows: MapRow[] = [];
+    for (const items of Object.values(positioned)) {
+      for (const { rows } of items) allRows.push(...rows);
+    }
+    return buildOccupiedFromRows(allRows, occupancyPerSection);
+  }, [positioned, occupancyPerSection]);
+
+  const handleToggle = useCallback((seat: SelectedSeat) => onToggleSeat(seat), [onToggleSeat]);
+
+  const legend = (
+    <div className="flex flex-wrap items-center justify-center gap-4 mt-5 pt-4 border-t border-border w-full">
+      {sections.map((s, i) => {
+        const p = PALETTE[i % PALETTE.length];
+        const cnt = selectedSeats.filter((x) => x.sectionId === s.id).length;
+        return (
+          <div key={s.id} className="flex items-center gap-1.5">
+            <div className="w-4 h-4 rounded-sm" style={{ backgroundColor: p.available }} />
+            <span className="text-xs text-muted-foreground">
+              {s.name}{cnt > 0 && <span className="font-bold text-foreground"> ({cnt})</span>}
+            </span>
+          </div>
+        );
+      })}
+      <div className="flex items-center gap-1.5">
+        <div className="w-4 h-4 rounded-sm bg-muted-foreground/20" />
+        <span className="text-xs text-muted-foreground">Ocupado</span>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <div className="w-4 h-4 rounded-sm flex items-center justify-center text-white text-[8px] font-bold" style={{ backgroundColor: PALETTE[0].available }}>✓</div>
+        <span className="text-xs text-muted-foreground">Seleccionado</span>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="min-w-fit flex flex-col items-center gap-2 pb-4">
+
+        {positioned.norte.length > 0 && (
+          <div className="flex flex-col items-center gap-1">
+            <div className="flex gap-2 mb-1">
+              {positioned.norte.map(({ section, pi }) => <SectionBadge key={section.id} name={section.name} pi={pi} />)}
+            </div>
+            {positioned.norte.map(({ section, rows }) => (
+              <HorizRows key={section.id} rows={rows} cols={HORIZ_COLS} sectionMap={sectionMap}
+                selectedIds={selectedIds} occupiedIds={occupiedIds} maxReached={maxReached} onToggle={handleToggle} />
+            ))}
+          </div>
+        )}
+
+        <div className="flex items-center gap-3">
+          {positioned.occidental.length > 0 ? (
+            <div className="flex flex-col items-center gap-1">
+              {positioned.occidental.map(({ section, rows, pi }) => (
+                <div key={section.id} className="flex flex-col items-center gap-1">
+                  <SectionBadge name={section.name} pi={pi} />
+                  <VertCols rows={rows} reversed sectionMap={sectionMap}
+                    selectedIds={selectedIds} occupiedIds={occupiedIds} maxReached={maxReached} onToggle={handleToggle} />
+                </div>
+              ))}
+            </div>
+          ) : <div className="w-6" />}
+
+          <OvalField />
+
+          {positioned.oriental.length > 0 ? (
+            <div className="flex flex-col items-center gap-1">
+              {positioned.oriental.map(({ section, rows, pi }) => (
+                <div key={section.id} className="flex flex-col items-center gap-1">
+                  <SectionBadge name={section.name} pi={pi} />
+                  <VertCols rows={rows} reversed={false} sectionMap={sectionMap}
+                    selectedIds={selectedIds} occupiedIds={occupiedIds} maxReached={maxReached} onToggle={handleToggle} />
+                </div>
+              ))}
+            </div>
+          ) : <div className="w-6" />}
+        </div>
+
+        {positioned.sur.length > 0 && (
+          <div className="flex flex-col items-center gap-1">
+            {positioned.sur.map(({ section, rows }) => (
+              <HorizRows key={section.id} rows={rows} cols={HORIZ_COLS} sectionMap={sectionMap}
+                selectedIds={selectedIds} occupiedIds={occupiedIds} maxReached={maxReached} onToggle={handleToggle} />
+            ))}
+            <div className="flex gap-2 mt-1">
+              {positioned.sur.map(({ section, pi }) => <SectionBadge key={section.id} name={section.name} pi={pi} />)}
+            </div>
+          </div>
+        )}
+
+        {positioned.extra.length > 0 && (
+          <div className="flex flex-col items-center gap-2 mt-2 pt-2 border-t border-border/40 w-full">
+            {positioned.extra.map(({ section, rows, pi }) => (
+              <div key={section.id} className="flex flex-col items-center gap-1">
+                <SectionBadge name={section.name} pi={pi} />
+                <HorizRows rows={rows} cols={HORIZ_COLS} sectionMap={sectionMap}
+                  selectedIds={selectedIds} occupiedIds={occupiedIds} maxReached={maxReached} onToggle={handleToggle} />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {legend}
+      </div>
+    </div>
+  );
+}
+
+// ── Cinema layout ──────────────────────────────────────────────────────────
+
+const MAX_CINEMA_SEATS = 150;
+
+function buildCinemaLayout(sections: SectionConfig[]): { rows: MapRow[]; cols: number } {
+  const capped = sections.map((s) => ({ ...s, capacity: Math.min(s.capacity, MAX_CINEMA_SEATS) }));
+  const total = capped.reduce((a, s) => a + Math.max(1, s.capacity), 0);
+  const cols = Math.min(20, Math.max(8, Math.ceil(Math.sqrt(total * 1.5))));
+  const rows: MapRow[] = [];
+  let rowIdx = 0;
+  capped.forEach((s, si) => {
+    const cap = Math.max(1, s.capacity);
+    const numRows = Math.ceil(cap / cols);
+    let remaining = cap;
+    for (let r = 0; r < numRows; r++) {
+      const label = String.fromCharCode(65 + (rowIdx % 26));
+      const n = Math.min(cols, remaining);
+      const seats = Array.from({ length: n }, (_, c) => ({
+        id: `${s.id}-${label}${c + 1}`,
+        row: label,
+        number: c + 1,
+      }));
+      rows.push({ label, seats, sectionId: s.id, sectionIndex: si, isFirstRow: r === 0 });
+      remaining -= n;
+      rowIdx++;
+    }
+  });
+  return { rows, cols };
+}
+
+interface CinemaLayoutProps {
+  venueType: VenueType;
+  sections: SectionConfig[];
+  selectedSeats: SelectedSeat[];
+  onToggleSeat: (seat: SelectedSeat) => void;
+  maxSeats: number;
+  occupancyPerSection: Record<string, number>;
+}
+
+function CinemaLayout({ venueType, sections, selectedSeats, onToggleSeat, maxSeats, occupancyPerSection }: CinemaLayoutProps) {
+  const maxReached = selectedSeats.length >= maxSeats;
+  const selectedIds = useMemo(() => new Set(selectedSeats.map((s) => s.id)), [selectedSeats]);
+  const { rows, cols } = useMemo(() => buildCinemaLayout(sections), [sections]);
+  const sectionMap = useMemo(() => {
+    const m: Record<string, SectionConfig> = {};
+    for (const s of sections) m[s.id] = s;
+    return m;
+  }, [sections]);
+
+  const occupiedIds = useMemo(
+    () => buildOccupiedFromRows(rows, occupancyPerSection),
+    [rows, occupancyPerSection]
+  );
+
+  const handleToggle = useCallback((seat: SelectedSeat) => onToggleSeat(seat), [onToggleSeat]);
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="min-w-fit px-2 pb-4">
+        <Stage venueType={venueType} />
+
+        <div className="space-y-0">
+          {rows.map((row) => {
+            const section = sectionMap[row.sectionId];
+            return (
+              <div key={`${row.sectionId}-${row.label}`}>
+                {row.isFirstRow && section && <SectionHeader section={section} pi={row.sectionIndex} />}
+                <div className="flex items-center justify-center gap-1 mb-[3px]">
+                  <span className="w-5 shrink-0 text-[10px] font-bold text-muted-foreground text-right select-none">{row.label}</span>
+                  <div className="flex gap-[4px]">
+                    {row.seats.map((seat) => (
+                      <SeatBtn key={seat.id} seat={seat} sectionId={row.sectionId} sectionIndex={row.sectionIndex}
+                        sectionMap={sectionMap} selectedIds={selectedIds} occupiedIds={occupiedIds}
+                        maxReached={maxReached} onToggle={handleToggle} />
+                    ))}
+                    {Array.from({ length: cols - row.seats.length }).map((_, i) => (
+                      <div key={`pad-${i}`} className="w-6 h-6" />
+                    ))}
+                  </div>
+                  <span className="w-5 shrink-0 text-[10px] font-bold text-muted-foreground text-left select-none">{row.label}</span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="flex flex-wrap items-center justify-center gap-5 mt-6 pt-4 border-t border-border">
+          {sections.map((s, i) => {
+            const p = PALETTE[i % PALETTE.length];
+            const cnt = selectedSeats.filter((x) => x.sectionId === s.id).length;
+            return (
+              <div key={s.id} className="flex items-center gap-1.5">
+                <div className="w-4 h-4 rounded-sm" style={{ backgroundColor: p.available }} />
+                <span className="text-xs text-muted-foreground">
+                  {s.name}{cnt > 0 && <span className="font-bold text-foreground"> ({cnt})</span>}
+                </span>
+              </div>
+            );
+          })}
+          <div className="flex items-center gap-1.5">
+            <div className="w-4 h-4 rounded-sm bg-muted-foreground/20" />
+            <span className="text-xs text-muted-foreground">Ocupado</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <div className="w-4 h-4 rounded-sm flex items-center justify-center text-white text-[9px] font-bold" style={{ backgroundColor: PALETTE[0].available }}>✓</div>
+            <span className="text-xs text-muted-foreground">Seleccionado</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Main SeatMap ───────────────────────────────────────────────────────────
+
+export function SeatMap({ venueType, venueName, sections, selectedSeats, onToggleSeat, maxSeats = 10, occupancyPerSection = {} }: SeatMapProps) {
+  const maxReached = selectedSeats.length >= maxSeats;
+  const isStadium = venueType === "STADIUM" || venueType === "COLISEUM";
+
+  if (sections.length === 0) {
+    return <p className="text-sm text-muted-foreground text-center py-8">No hay secciones configuradas para este evento.</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <span className="text-xs text-muted-foreground font-medium">{venueName}</span>
+        {maxReached && <span className="text-xs text-destructive font-bold">Máximo {maxSeats} asientos</span>}
+      </div>
+
+      {isStadium ? (
+        <StadiumLayout
+          sections={sections}
+          selectedSeats={selectedSeats}
+          onToggleSeat={onToggleSeat}
+          maxSeats={maxSeats}
+          occupancyPerSection={occupancyPerSection}
+        />
+      ) : (
+        <CinemaLayout
+          venueType={venueType}
+          sections={sections}
+          selectedSeats={selectedSeats}
+          onToggleSeat={onToggleSeat}
+          maxSeats={maxSeats}
+          occupancyPerSection={occupancyPerSection}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/SeatMap.tsx
+++ b/frontend/src/components/ui/SeatMap.tsx
@@ -6,13 +6,24 @@ export type VenueType =
   | "STADIUM" | "THEATER" | "ARENA"
   | "CLUB" | "COLISEUM" | "CONVENTION_CENTER";
 
+export type SeatStatus = "AVAILABLE" | "HELD" | "SOLD" | "BLOCKED";
+
+export interface SeatData {
+  seatId: string;
+  label: string;
+  row: string;
+  number: number;
+  status: SeatStatus;
+}
+
 export interface SectionConfig {
   id: string;
   name: string;
+  ticketTypeId: string;
   price: number;
   serviceFee: number;
-  capacity: number;
   maxPerOrder: number;
+  seats: SeatData[];
 }
 
 export interface SelectedSeat {
@@ -36,8 +47,6 @@ interface SeatMapProps {
   selectedSeats: SelectedSeat[];
   onToggleSeat: (seat: SelectedSeat) => void;
   maxSeats?: number;
-  /** sold/active ticket count per sectionId (ticket_type id) */
-  occupancyPerSection?: Record<string, number>;
 }
 
 // ── Palette ────────────────────────────────────────────────────────────────
@@ -56,77 +65,80 @@ function hexAlpha(hex: string, alpha: number): string {
 
 // ── Row type ───────────────────────────────────────────────────────────────
 
+interface RenderSeat {
+  id: string;
+  row: string;
+  number: number;
+  status: SeatStatus;
+}
+
 interface MapRow {
   label: string;
-  seats: { id: string; row: string; number: number }[];
+  seats: RenderSeat[];
   sectionId: string;
   sectionIndex: number;
   isFirstRow: boolean;
 }
 
-// ── Build rows for a section ───────────────────────────────────────────────
+// ── Group real seats from the API into rows for rendering ──────────────────
+// Uses the seat's actual row_label and seat_number from the DB.
 
-function buildRows(section: SectionConfig, sectionIndex: number, colCount: number, maxRows: number): MapRow[] {
-  const cap = Math.min(section.capacity, colCount * maxRows);
-  const numRows = Math.min(maxRows, Math.ceil(cap / colCount));
-  const rows: MapRow[] = [];
-  let remaining = cap;
-  for (let r = 0; r < numRows; r++) {
-    const label = String.fromCharCode(65 + r);
-    const n = Math.min(colCount, remaining);
-    const seats = Array.from({ length: n }, (_, c) => ({
-      id: `${section.id}-${label}${c + 1}`,
-      row: label,
-      number: c + 1,
-    }));
-    rows.push({ label, seats, sectionId: section.id, sectionIndex, isFirstRow: r === 0 });
-    remaining -= n;
+function buildRowsFromSeats(section: SectionConfig, sectionIndex: number): MapRow[] {
+  const byRow = new Map<string, SeatData[]>();
+  for (const seat of section.seats) {
+    const key = seat.row || "";
+    const arr = byRow.get(key) ?? [];
+    arr.push(seat);
+    byRow.set(key, arr);
   }
-  return rows;
-}
 
-// ── Build occupied set from real occupancy counts ──────────────────────────
-// Marks the first N seat IDs (in row order) as occupied for each section.
-
-function buildOccupiedFromRows(rows: MapRow[], occupancyPerSection: Record<string, number>): Set<string> {
-  const occupied = new Set<string>();
-  const added: Record<string, number> = {};
-  for (const row of rows) {
-    const quota = occupancyPerSection[row.sectionId] ?? 0;
-    for (const seat of row.seats) {
-      if ((added[row.sectionId] ?? 0) >= quota) break;
-      occupied.add(seat.id);
-      added[row.sectionId] = (added[row.sectionId] ?? 0) + 1;
-    }
-  }
-  return occupied;
+  const sortedRowKeys = [...byRow.keys()].sort();
+  return sortedRowKeys.map((rowKey, i) => {
+    const seats = (byRow.get(rowKey) ?? [])
+      .slice()
+      .sort((a, b) => a.number - b.number)
+      .map<RenderSeat>((s) => ({
+        id: s.seatId,
+        row: s.row,
+        number: s.number,
+        status: s.status,
+      }));
+    return {
+      label: rowKey || String.fromCharCode(65 + i),
+      seats,
+      sectionId: section.id,
+      sectionIndex,
+      isFirstRow: i === 0,
+    };
+  });
 }
 
 // ── Shared seat button ─────────────────────────────────────────────────────
 
 interface SeatBtnProps {
-  seat: { id: string; row: string; number: number };
+  seat: RenderSeat;
   sectionId: string;
   sectionIndex: number;
   sectionMap: Record<string, SectionConfig>;
   selectedIds: Set<string>;
-  occupiedIds: Set<string>;
   maxReached: boolean;
   onToggle: (seat: SelectedSeat) => void;
   size?: "sm" | "xs";
 }
 
-function SeatBtn({ seat, sectionId, sectionIndex, sectionMap, selectedIds, occupiedIds, maxReached, onToggle, size = "sm" }: SeatBtnProps) {
+function SeatBtn({ seat, sectionId, sectionIndex, sectionMap, selectedIds, maxReached, onToggle, size = "sm" }: SeatBtnProps) {
   const isSel = selectedIds.has(seat.id);
-  const isOcc = occupiedIds.has(seat.id);
-  const isBlocked = !isSel && !isOcc && maxReached;
-  const disabled = isOcc || isBlocked;
+  const isOcc = seat.status === "SOLD" || seat.status === "HELD";
+  const isBlockedSeat = seat.status === "BLOCKED";
+  const isCapped = !isSel && !isOcc && !isBlockedSeat && maxReached;
+  const disabled = isOcc || isBlockedSeat || isCapped;
   const p = PALETTE[sectionIndex % PALETTE.length];
   const section = sectionMap[sectionId];
   const dim = size === "xs" ? "w-5 h-5 text-[7px]" : "w-6 h-6 text-[8px]";
 
   let bgStyle: React.CSSProperties = {};
   let extraClass = "";
+  let title = "";
 
   if (isSel) {
     bgStyle = {
@@ -135,9 +147,14 @@ function SeatBtn({ seat, sectionId, sectionIndex, sectionMap, selectedIds, occup
       boxShadow: `0 0 0 2px white, 0 0 0 3.5px ${p.available}`,
     };
     extraClass = "scale-110 cursor-pointer";
+    title = "Seleccionado";
   } else if (isOcc) {
     extraClass = "bg-muted-foreground/20 text-transparent cursor-not-allowed";
-  } else if (isBlocked) {
+    title = seat.status === "SOLD" ? "Asiento vendido" : "Asiento reservado";
+  } else if (isBlockedSeat) {
+    extraClass = "bg-muted/40 text-transparent cursor-not-allowed opacity-40";
+    title = "Asiento bloqueado";
+  } else if (isCapped) {
     extraClass = "bg-muted/60 text-transparent cursor-not-allowed opacity-50";
   } else {
     bgStyle = {
@@ -145,6 +162,7 @@ function SeatBtn({ seat, sectionId, sectionIndex, sectionMap, selectedIds, occup
       color: p.available,
     };
     extraClass = "hover:scale-105 active:scale-95 cursor-pointer";
+    title = `${seat.row}${seat.number} · ${section?.name} · $${section?.price.toLocaleString("es-CO")}`;
   }
 
   return (
@@ -159,16 +177,16 @@ function SeatBtn({ seat, sectionId, sectionIndex, sectionMap, selectedIds, occup
           label: `${section.name} ${seat.row}${seat.number}`,
           sectionId: section.id,
           sectionName: section.name,
-          ticketTypeId: section.id,
+          ticketTypeId: section.ticketTypeId,
           price: section.price,
           serviceFee: section.serviceFee,
         });
       }}
-      title={isOcc ? "Asiento ocupado" : `${seat.row}${seat.number} · ${section?.name} · $${section?.price.toLocaleString("es-CO")}`}
+      title={title}
       style={bgStyle}
       className={`${dim} rounded-sm font-bold flex items-center justify-center transition-transform select-none border-0 outline-none shrink-0 ${extraClass}`}
     >
-      {isSel ? "✓" : isOcc ? "" : seat.number}
+      {isSel ? "✓" : (isOcc || isBlockedSeat) ? "" : seat.number}
     </button>
   );
 }
@@ -204,12 +222,11 @@ interface HorizRowsProps {
   cols: number;
   sectionMap: Record<string, SectionConfig>;
   selectedIds: Set<string>;
-  occupiedIds: Set<string>;
   maxReached: boolean;
   onToggle: (seat: SelectedSeat) => void;
 }
 
-function HorizRows({ rows, cols, sectionMap, selectedIds, occupiedIds, maxReached, onToggle }: HorizRowsProps) {
+function HorizRows({ rows, cols, sectionMap, selectedIds, maxReached, onToggle }: HorizRowsProps) {
   return (
     <div className="space-y-[3px]">
       {rows.map((row) => (
@@ -218,9 +235,9 @@ function HorizRows({ rows, cols, sectionMap, selectedIds, occupiedIds, maxReache
           <div className="flex gap-[3px]">
             {row.seats.map((seat) => (
               <SeatBtn key={seat.id} seat={seat} sectionId={row.sectionId} sectionIndex={row.sectionIndex}
-                sectionMap={sectionMap} selectedIds={selectedIds} occupiedIds={occupiedIds} maxReached={maxReached} onToggle={onToggle} />
+                sectionMap={sectionMap} selectedIds={selectedIds} maxReached={maxReached} onToggle={onToggle} />
             ))}
-            {Array.from({ length: cols - row.seats.length }).map((_, i) => (
+            {Array.from({ length: Math.max(0, cols - row.seats.length) }).map((_, i) => (
               <div key={`pad${i}`} className="w-6 h-6 shrink-0" />
             ))}
           </div>
@@ -238,12 +255,11 @@ interface VertColsProps {
   reversed: boolean;
   sectionMap: Record<string, SectionConfig>;
   selectedIds: Set<string>;
-  occupiedIds: Set<string>;
   maxReached: boolean;
   onToggle: (seat: SelectedSeat) => void;
 }
 
-function VertCols({ rows, reversed, sectionMap, selectedIds, occupiedIds, maxReached, onToggle }: VertColsProps) {
+function VertCols({ rows, reversed, sectionMap, selectedIds, maxReached, onToggle }: VertColsProps) {
   const display = reversed ? [...rows].reverse() : rows;
   return (
     <div className="flex gap-[3px]">
@@ -251,7 +267,7 @@ function VertCols({ rows, reversed, sectionMap, selectedIds, occupiedIds, maxRea
         <div key={`${row.sectionId}-${row.label}`} className="flex flex-col gap-[3px]">
           {row.seats.map((seat) => (
             <SeatBtn key={seat.id} seat={seat} sectionId={row.sectionId} sectionIndex={row.sectionIndex}
-              sectionMap={sectionMap} selectedIds={selectedIds} occupiedIds={occupiedIds} maxReached={maxReached} onToggle={onToggle} size="xs" />
+              sectionMap={sectionMap} selectedIds={selectedIds} maxReached={maxReached} onToggle={onToggle} size="xs" />
           ))}
         </div>
       ))}
@@ -328,20 +344,14 @@ function getStadiumPos(name: string, index: number): StadiumPos {
 
 // ── Stadium layout ─────────────────────────────────────────────────────────
 
-const HORIZ_COLS = 14;
-const HORIZ_MAX_ROWS = 10;
-const VERT_SEATS = 10;
-const VERT_MAX_COLS = 8;
-
 interface StadiumLayoutProps {
   sections: SectionConfig[];
   selectedSeats: SelectedSeat[];
   onToggleSeat: (seat: SelectedSeat) => void;
   maxSeats: number;
-  occupancyPerSection: Record<string, number>;
 }
 
-function StadiumLayout({ sections, selectedSeats, onToggleSeat, maxSeats, occupancyPerSection }: StadiumLayoutProps) {
+function StadiumLayout({ sections, selectedSeats, onToggleSeat, maxSeats }: StadiumLayoutProps) {
   const maxReached = selectedSeats.length >= maxSeats;
   const selectedIds = useMemo(() => new Set(selectedSeats.map((s) => s.id)), [selectedSeats]);
   const sectionMap = useMemo(() => {
@@ -351,26 +361,17 @@ function StadiumLayout({ sections, selectedSeats, onToggleSeat, maxSeats, occupa
   }, [sections]);
 
   const positioned = useMemo(() => {
-    const r: Record<StadiumPos, Array<{ section: SectionConfig; rows: MapRow[]; pi: number }>> = {
+    const r: Record<StadiumPos, Array<{ section: SectionConfig; rows: MapRow[]; pi: number; cols: number }>> = {
       norte: [], sur: [], occidental: [], oriental: [], extra: [],
     };
     sections.forEach((s, i) => {
       const pos = getStadiumPos(s.name, i);
-      const isVert = pos === "occidental" || pos === "oriental";
-      const rows = buildRows(s, i, isVert ? VERT_SEATS : HORIZ_COLS, isVert ? VERT_MAX_COLS : HORIZ_MAX_ROWS);
-      r[pos].push({ section: s, rows, pi: i });
+      const rows = buildRowsFromSeats(s, i);
+      const cols = rows.reduce((m, r) => Math.max(m, r.seats.length), 0);
+      r[pos].push({ section: s, rows, pi: i, cols });
     });
     return r;
   }, [sections]);
-
-  // Build occupied set from all rows across all positions
-  const occupiedIds = useMemo(() => {
-    const allRows: MapRow[] = [];
-    for (const items of Object.values(positioned)) {
-      for (const { rows } of items) allRows.push(...rows);
-    }
-    return buildOccupiedFromRows(allRows, occupancyPerSection);
-  }, [positioned, occupancyPerSection]);
 
   const handleToggle = useCallback((seat: SelectedSeat) => onToggleSeat(seat), [onToggleSeat]);
 
@@ -408,9 +409,9 @@ function StadiumLayout({ sections, selectedSeats, onToggleSeat, maxSeats, occupa
             <div className="flex gap-2 mb-1">
               {positioned.norte.map(({ section, pi }) => <SectionBadge key={section.id} name={section.name} pi={pi} />)}
             </div>
-            {positioned.norte.map(({ section, rows }) => (
-              <HorizRows key={section.id} rows={rows} cols={HORIZ_COLS} sectionMap={sectionMap}
-                selectedIds={selectedIds} occupiedIds={occupiedIds} maxReached={maxReached} onToggle={handleToggle} />
+            {positioned.norte.map(({ section, rows, cols }) => (
+              <HorizRows key={section.id} rows={rows} cols={cols} sectionMap={sectionMap}
+                selectedIds={selectedIds} maxReached={maxReached} onToggle={handleToggle} />
             ))}
           </div>
         )}
@@ -422,7 +423,7 @@ function StadiumLayout({ sections, selectedSeats, onToggleSeat, maxSeats, occupa
                 <div key={section.id} className="flex flex-col items-center gap-1">
                   <SectionBadge name={section.name} pi={pi} />
                   <VertCols rows={rows} reversed sectionMap={sectionMap}
-                    selectedIds={selectedIds} occupiedIds={occupiedIds} maxReached={maxReached} onToggle={handleToggle} />
+                    selectedIds={selectedIds} maxReached={maxReached} onToggle={handleToggle} />
                 </div>
               ))}
             </div>
@@ -436,7 +437,7 @@ function StadiumLayout({ sections, selectedSeats, onToggleSeat, maxSeats, occupa
                 <div key={section.id} className="flex flex-col items-center gap-1">
                   <SectionBadge name={section.name} pi={pi} />
                   <VertCols rows={rows} reversed={false} sectionMap={sectionMap}
-                    selectedIds={selectedIds} occupiedIds={occupiedIds} maxReached={maxReached} onToggle={handleToggle} />
+                    selectedIds={selectedIds} maxReached={maxReached} onToggle={handleToggle} />
                 </div>
               ))}
             </div>
@@ -445,9 +446,9 @@ function StadiumLayout({ sections, selectedSeats, onToggleSeat, maxSeats, occupa
 
         {positioned.sur.length > 0 && (
           <div className="flex flex-col items-center gap-1">
-            {positioned.sur.map(({ section, rows }) => (
-              <HorizRows key={section.id} rows={rows} cols={HORIZ_COLS} sectionMap={sectionMap}
-                selectedIds={selectedIds} occupiedIds={occupiedIds} maxReached={maxReached} onToggle={handleToggle} />
+            {positioned.sur.map(({ section, rows, cols }) => (
+              <HorizRows key={section.id} rows={rows} cols={cols} sectionMap={sectionMap}
+                selectedIds={selectedIds} maxReached={maxReached} onToggle={handleToggle} />
             ))}
             <div className="flex gap-2 mt-1">
               {positioned.sur.map(({ section, pi }) => <SectionBadge key={section.id} name={section.name} pi={pi} />)}
@@ -457,11 +458,11 @@ function StadiumLayout({ sections, selectedSeats, onToggleSeat, maxSeats, occupa
 
         {positioned.extra.length > 0 && (
           <div className="flex flex-col items-center gap-2 mt-2 pt-2 border-t border-border/40 w-full">
-            {positioned.extra.map(({ section, rows, pi }) => (
+            {positioned.extra.map(({ section, rows, pi, cols }) => (
               <div key={section.id} className="flex flex-col items-center gap-1">
                 <SectionBadge name={section.name} pi={pi} />
-                <HorizRows rows={rows} cols={HORIZ_COLS} sectionMap={sectionMap}
-                  selectedIds={selectedIds} occupiedIds={occupiedIds} maxReached={maxReached} onToggle={handleToggle} />
+                <HorizRows rows={rows} cols={cols} sectionMap={sectionMap}
+                  selectedIds={selectedIds} maxReached={maxReached} onToggle={handleToggle} />
               </div>
             ))}
           </div>
@@ -475,57 +476,37 @@ function StadiumLayout({ sections, selectedSeats, onToggleSeat, maxSeats, occupa
 
 // ── Cinema layout ──────────────────────────────────────────────────────────
 
-const MAX_CINEMA_SEATS = 150;
-
-function buildCinemaLayout(sections: SectionConfig[]): { rows: MapRow[]; cols: number } {
-  const capped = sections.map((s) => ({ ...s, capacity: Math.min(s.capacity, MAX_CINEMA_SEATS) }));
-  const total = capped.reduce((a, s) => a + Math.max(1, s.capacity), 0);
-  const cols = Math.min(20, Math.max(8, Math.ceil(Math.sqrt(total * 1.5))));
-  const rows: MapRow[] = [];
-  let rowIdx = 0;
-  capped.forEach((s, si) => {
-    const cap = Math.max(1, s.capacity);
-    const numRows = Math.ceil(cap / cols);
-    let remaining = cap;
-    for (let r = 0; r < numRows; r++) {
-      const label = String.fromCharCode(65 + (rowIdx % 26));
-      const n = Math.min(cols, remaining);
-      const seats = Array.from({ length: n }, (_, c) => ({
-        id: `${s.id}-${label}${c + 1}`,
-        row: label,
-        number: c + 1,
-      }));
-      rows.push({ label, seats, sectionId: s.id, sectionIndex: si, isFirstRow: r === 0 });
-      remaining -= n;
-      rowIdx++;
-    }
-  });
-  return { rows, cols };
-}
-
 interface CinemaLayoutProps {
   venueType: VenueType;
   sections: SectionConfig[];
   selectedSeats: SelectedSeat[];
   onToggleSeat: (seat: SelectedSeat) => void;
   maxSeats: number;
-  occupancyPerSection: Record<string, number>;
 }
 
-function CinemaLayout({ venueType, sections, selectedSeats, onToggleSeat, maxSeats, occupancyPerSection }: CinemaLayoutProps) {
+function CinemaLayout({ venueType, sections, selectedSeats, onToggleSeat, maxSeats }: CinemaLayoutProps) {
   const maxReached = selectedSeats.length >= maxSeats;
   const selectedIds = useMemo(() => new Set(selectedSeats.map((s) => s.id)), [selectedSeats]);
-  const { rows, cols } = useMemo(() => buildCinemaLayout(sections), [sections]);
   const sectionMap = useMemo(() => {
     const m: Record<string, SectionConfig> = {};
     for (const s of sections) m[s.id] = s;
     return m;
   }, [sections]);
 
-  const occupiedIds = useMemo(
-    () => buildOccupiedFromRows(rows, occupancyPerSection),
-    [rows, occupancyPerSection]
-  );
+  const { rows, cols } = useMemo(() => {
+    const all: MapRow[] = [];
+    let rowIdx = 0;
+    let maxCols = 0;
+    sections.forEach((s, si) => {
+      const sectionRows = buildRowsFromSeats(s, si);
+      sectionRows.forEach((r, j) => {
+        all.push({ ...r, isFirstRow: j === 0 });
+        maxCols = Math.max(maxCols, r.seats.length);
+        rowIdx++;
+      });
+    });
+    return { rows: all, cols: maxCols };
+  }, [sections]);
 
   const handleToggle = useCallback((seat: SelectedSeat) => onToggleSeat(seat), [onToggleSeat]);
 
@@ -545,10 +526,10 @@ function CinemaLayout({ venueType, sections, selectedSeats, onToggleSeat, maxSea
                   <div className="flex gap-[4px]">
                     {row.seats.map((seat) => (
                       <SeatBtn key={seat.id} seat={seat} sectionId={row.sectionId} sectionIndex={row.sectionIndex}
-                        sectionMap={sectionMap} selectedIds={selectedIds} occupiedIds={occupiedIds}
+                        sectionMap={sectionMap} selectedIds={selectedIds}
                         maxReached={maxReached} onToggle={handleToggle} />
                     ))}
-                    {Array.from({ length: cols - row.seats.length }).map((_, i) => (
+                    {Array.from({ length: Math.max(0, cols - row.seats.length) }).map((_, i) => (
                       <div key={`pad-${i}`} className="w-6 h-6" />
                     ))}
                   </div>
@@ -588,7 +569,7 @@ function CinemaLayout({ venueType, sections, selectedSeats, onToggleSeat, maxSea
 
 // ── Main SeatMap ───────────────────────────────────────────────────────────
 
-export function SeatMap({ venueType, venueName, sections, selectedSeats, onToggleSeat, maxSeats = 10, occupancyPerSection = {} }: SeatMapProps) {
+export function SeatMap({ venueType, venueName, sections, selectedSeats, onToggleSeat, maxSeats = 10 }: SeatMapProps) {
   const maxReached = selectedSeats.length >= maxSeats;
   const isStadium = venueType === "STADIUM" || venueType === "COLISEUM";
 
@@ -609,7 +590,6 @@ export function SeatMap({ venueType, venueName, sections, selectedSeats, onToggl
           selectedSeats={selectedSeats}
           onToggleSeat={onToggleSeat}
           maxSeats={maxSeats}
-          occupancyPerSection={occupancyPerSection}
         />
       ) : (
         <CinemaLayout
@@ -618,7 +598,6 @@ export function SeatMap({ venueType, venueName, sections, selectedSeats, onToggl
           selectedSeats={selectedSeats}
           onToggleSeat={onToggleSeat}
           maxSeats={maxSeats}
-          occupancyPerSection={occupancyPerSection}
         />
       )}
     </div>

--- a/frontend/src/components/ui/TicketCard.tsx
+++ b/frontend/src/components/ui/TicketCard.tsx
@@ -2,16 +2,33 @@ import { QrCode, MapPin, Calendar, ShieldCheck, Lock, ExternalLink, Tag } from "
 import { QRCodeCanvas } from "qrcode.react";
 import type { PurchasedTicket } from "@/context/AppContext";
 import { useAppContext } from "@/context/AppContext";
+import { useXlmPrice, formatCOP } from "@/hooks/useXlmPrice";
 import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 
 export const TicketCard = ({ ticket }: { ticket: PurchasedTicket }) => {
   const { secureTicketOnChain, listTicketForSale, cancelResaleListing, walletAddress } = useAppContext();
+  const xlmCopPrice = useXlmPrice();
   const [isMinting, setIsMinting] = useState(false);
   const [isMinted, setIsMinted] = useState(ticket.isSecuredOnChain ?? false);
   const [isListing, setIsListing] = useState(false);
   const [isListed, setIsListed] = useState(ticket.isForSale ?? false);
   const [isCancelling, setIsCancelling] = useState(false);
   const [txHash, setTxHash] = useState<string | null>(null);
+  const [resaleDialogOpen, setResaleDialogOpen] = useState(false);
+  const [resalePriceInput, setResalePriceInput] = useState("");
+
+  const parsedPriceCOP = Number(resalePriceInput.replace(/[^\d]/g, ""));
+  const previewXLM = xlmCopPrice && parsedPriceCOP > 0 ? parsedPriceCOP / xlmCopPrice : 0;
 
   const claimTicket = async () => {
     if (!walletAddress) {
@@ -35,17 +52,26 @@ export const TicketCard = ({ ticket }: { ticket: PurchasedTicket }) => {
     }
   };
 
-  const handleListForSale = async () => {
+  const openResaleDialog = () => {
     if (!walletAddress) {
       alert("Debes conectar tu wallet de Freighter antes de poner el boleto en reventa. Haz clic en \"Conectar Wallet\" en la parte superior de la página.");
       return;
     }
-    const priceStr = prompt("Ingresa el precio de reventa en XLM:");
-    if (!priceStr || isNaN(Number(priceStr)) || Number(priceStr) <= 0) return;
+    if (!xlmCopPrice) {
+      alert("No se pudo obtener la cotización XLM/COP. Intenta de nuevo en unos segundos.");
+      return;
+    }
+    setResalePriceInput("");
+    setResaleDialogOpen(true);
+  };
 
+  const confirmResaleListing = async () => {
+    if (!xlmCopPrice || parsedPriceCOP <= 0) return;
+    const priceXLM = parsedPriceCOP / xlmCopPrice;
+    setResaleDialogOpen(false);
     try {
       setIsListing(true);
-      const result = await listTicketForSale(ticket.id, Number(priceStr));
+      const result = await listTicketForSale(ticket.id, priceXLM);
       if (result.success) {
         setIsListed(true);
         setTxHash(result.txHash ?? txHash);
@@ -67,6 +93,7 @@ export const TicketCard = ({ ticket }: { ticket: PurchasedTicket }) => {
       : null;
 
   return (
+  <>
   <div className="bg-card rounded-xl border border-border overflow-hidden flex flex-col sm:flex-row">
     <img
       src={ticket.event.image}
@@ -146,7 +173,7 @@ export const TicketCard = ({ ticket }: { ticket: PurchasedTicket }) => {
             </div>
             {!isListed && (
               <button
-                onClick={handleListForSale}
+                onClick={openResaleDialog}
                 disabled={isListing}
                 className={`inline-flex items-center gap-1 px-3 py-1 text-xs font-black rounded-lg transition-colors shadow-md shadow-blue-900/20 w-fit ${isListing ? "bg-muted text-muted-foreground" : "bg-blue-600 hover:bg-blue-700 text-white"}`}
               >
@@ -179,5 +206,64 @@ export const TicketCard = ({ ticket }: { ticket: PurchasedTicket }) => {
         <span className="text-[10px] text-muted-foreground font-bold mt-2 uppercase tracking-tight">{ticket.ticketCode?.slice(0, 10) || "QR-CODE"}</span>
       </div>
     </div>
+
+    <Dialog open={resaleDialogOpen} onOpenChange={setResaleDialogOpen}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Listar boleto en reventa</DialogTitle>
+          <DialogDescription>
+            Define el precio de reventa en pesos colombianos. Internamente se firma en XLM al precio actual del mercado.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="resale-price-cop">
+              Precio en COP
+            </label>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">$</span>
+              <Input
+                id="resale-price-cop"
+                type="text"
+                inputMode="numeric"
+                placeholder="100000"
+                value={resalePriceInput}
+                onChange={(e) => setResalePriceInput(e.target.value)}
+                className="pl-7"
+                autoFocus
+              />
+            </div>
+          </div>
+
+          <div className="rounded-lg bg-muted/50 p-3 space-y-1 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Equivalente en XLM:</span>
+              <span className="font-mono font-semibold">
+                {previewXLM > 0 ? `${previewXLM.toFixed(4)} XLM` : "—"}
+              </span>
+            </div>
+            <div className="flex justify-between text-xs text-muted-foreground">
+              <span>Cotización actual:</span>
+              <span>{xlmCopPrice ? `1 XLM ≈ ${formatCOP(xlmCopPrice)}` : "—"}</span>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button variant="outline" onClick={() => setResaleDialogOpen(false)}>
+            Cancelar
+          </Button>
+          <Button
+            onClick={confirmResaleListing}
+            disabled={parsedPriceCOP <= 0 || !xlmCopPrice}
+            className="bg-blue-600 hover:bg-blue-700 text-white"
+          >
+            Listar por {parsedPriceCOP > 0 ? formatCOP(parsedPriceCOP) : "—"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  </>
   );
 };

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -273,14 +273,14 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       };
 
       const cartData = await load("carrito", () =>
-        apiFetch<Array<{ id: string; quantity: number; seatIds?: string[]; ticketType?: { id: string; name: string; price: number; serviceFee: number } }>>("/api/cart")
+        apiFetch<Array<{ id: string; quantity: number; seatIds?: string[]; seatLabels?: string[]; ticketType?: { id: string; name: string; price: number; serviceFee: number } }>>("/api/cart")
       );
       if (cartData) {
         setCart(
           cartData.map((item) => ({
             id: item.id,
             quantity: item.quantity,
-            seats: item.seatIds,
+            seats: item.seatLabels ?? item.seatIds,
             ticketType: {
               id: item.ticketType?.id ?? "unknown",
               name: item.ticketType?.name ?? "Boleta",
@@ -343,29 +343,46 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     })();
   }, [apiFetch, token, user, mapTicketsResponse]);
 
+  const refreshCart = useCallback(async () => {
+    const cartData = await apiFetch<Array<{ id: string; quantity: number; seatIds?: string[]; seatLabels?: string[]; ticketType?: { id: string; name: string; price: number; serviceFee: number }; event?: Partial<EventData> }>>("/api/cart");
+    setCart(
+      cartData.map((item) => ({
+        id: item.id,
+        quantity: item.quantity,
+        seats: item.seatLabels ?? item.seatIds,
+        ticketType: {
+          id: item.ticketType?.id ?? "unknown",
+          name: item.ticketType?.name ?? "Boleta",
+          price: item.ticketType?.price ?? 0,
+          serviceFee: item.ticketType?.serviceFee ?? 0,
+          available: 0,
+          maxPerOrder: 10,
+        },
+        event: normalizeEventData(item.event),
+      }))
+    );
+  }, [apiFetch]);
+
   const addToCart = useCallback(
     async (item: Omit<CartItem, "id">) => {
-      const created = await apiFetch<{ id: string }>("/api/cart/items", {
+      // For seated tickets, item.seats holds seat UUIDs (from SeatSelection).
+      // For GA tickets, item.seats is undefined; only quantity matters.
+      const seatIds = item.seats;
+      const isSeated = Array.isArray(seatIds) && seatIds.length > 0;
+      await apiFetch<{ id: string }>("/api/cart/items", {
         method: "POST",
         body: JSON.stringify({
           eventId: item.event.id,
           ticketTypeId: item.ticketType.id,
-          quantity: item.quantity,
-          seatIds: item.seats,
+          quantity: isSeated ? undefined : item.quantity,
+          seatIds: isSeated ? seatIds : undefined,
         }),
       });
-      setCart((prev) => {
-        // If backend merged into existing item, replace it by ticket type
-        const existingIdx = prev.findIndex((c) => c.ticketType.id === item.ticketType.id && c.event.id === item.event.id);
-        if (existingIdx >= 0) {
-          const updated = [...prev];
-          updated[existingIdx] = { ...updated[existingIdx], id: created.id, quantity: updated[existingIdx].quantity + item.quantity };
-          return updated;
-        }
-        return [...prev, { ...item, id: created.id }];
-      });
+      // Re-fetch cart so seated tickets show real labels and per-seat rows
+      // (backend creates one cart_item per seat for assigned seating).
+      await refreshCart();
     },
-    [apiFetch]
+    [apiFetch, refreshCart]
   );
 
   const removeFromCart = useCallback(

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -101,6 +101,16 @@ interface AppState {
 
 const AppContext = createContext<AppState | null>(null);
 
+class ApiRequestError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ApiRequestError";
+    this.status = status;
+  }
+}
+
 export const useAppContext = () => {
   const ctx = useContext(AppContext);
   if (!ctx) throw new Error("useAppContext must be used within AppProvider");
@@ -128,8 +138,15 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       if (token) headers.set("Authorization", `Bearer ${token}`);
       const response = await fetch(`${API_BASE_URL}${path}`, { ...init, headers });
       if (!response.ok) {
-        const message = await response.text();
-        throw new Error(message || `Request failed: ${response.status}`);
+        const rawMessage = await response.text();
+        let message = rawMessage;
+        try {
+          const parsed = JSON.parse(rawMessage) as { error?: string; message?: string };
+          message = parsed.error ?? parsed.message ?? rawMessage;
+        } catch {
+          // Keep the plain response body when it is not JSON.
+        }
+        throw new ApiRequestError(response.status, message || `Request failed: ${response.status}`);
       }
       if (response.status === 204) return undefined as T;
       return response.json() as Promise<T>;

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -296,7 +296,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
 
   const addToCart = useCallback(
     async (item: Omit<CartItem, "id">) => {
-      await apiFetch("/api/cart/items", {
+      const created = await apiFetch<{ id: string }>("/api/cart/items", {
         method: "POST",
         body: JSON.stringify({
           eventId: item.event.id,
@@ -305,8 +305,16 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
           seatIds: item.seats,
         }),
       });
-      const id = `tmp-${Date.now()}`;
-      setCart((prev) => [...prev, { ...item, id }]);
+      setCart((prev) => {
+        // If backend merged into existing item, replace it by ticket type
+        const existingIdx = prev.findIndex((c) => c.ticketType.id === item.ticketType.id && c.event.id === item.event.id);
+        if (existingIdx >= 0) {
+          const updated = [...prev];
+          updated[existingIdx] = { ...updated[existingIdx], id: created.id, quantity: updated[existingIdx].quantity + item.quantity };
+          return updated;
+        }
+        return [...prev, { ...item, id: created.id }];
+      });
     },
     [apiFetch]
   );

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -26,6 +26,7 @@ export interface PurchasedTicket {
   ticketRootId?: number;
   version?: number;
   ownerWallet?: string;
+  resalePrice?: number;
 }
 
 /* ── Sold ticket ── */
@@ -100,6 +101,13 @@ interface AppState {
 }
 
 const AppContext = createContext<AppState | null>(null);
+
+const normalizeEventData = (event?: Partial<EventData>): EventData =>
+  ({
+    ...event,
+    image: (event as any)?.posterImage || (event as any)?.bannerImage || event?.image || "https://placehold.co/800x500?text=Evento",
+    bannerImage: (event as any)?.bannerImage || (event as any)?.posterImage || event?.bannerImage || "https://placehold.co/1200x400?text=Evento",
+  }) as EventData;
 
 class ApiRequestError extends Error {
   status: number;
@@ -206,10 +214,10 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   }, [refreshUserData, token]);
 
   const mapTicketsResponse = useCallback(
-    (ticketsData: Array<{ id: string; purchasedAt?: string; quantity: number; seatIds?: string[]; ticketType?: { id: string; name: string; price: number; serviceFee: number }; event?: Partial<EventData>; isSecuredOnChain?: boolean; isForSale?: boolean; contractAddress?: string; ticketRootId?: number; version?: number; ownerWallet?: string }>): PurchasedTicket[] =>
+    (ticketsData: Array<{ id: string; purchasedAt?: string; quantity: number; seatIds?: string[]; ticketType?: { id: string; name: string; price: number; serviceFee: number }; event?: Partial<EventData>; isSecuredOnChain?: boolean; isForSale?: boolean; contractAddress?: string; ticketRootId?: number; version?: number; ownerWallet?: string; resalePrice?: number | null }>): PurchasedTicket[] =>
       ticketsData.map((ticket) => ({
         id: ticket.id,
-        event: { ...ticket.event, image: (ticket.event as any)?.posterImage || (ticket.event as any)?.bannerImage || ticket.event?.image || "", bannerImage: (ticket.event as any)?.bannerImage || (ticket.event as any)?.posterImage || ticket.event?.bannerImage || "" } as EventData,
+        event: normalizeEventData(ticket.event),
         ticketCode: (ticket as any)?.ticketCode,
         ticketType: {
           id: ticket.ticketType?.id ?? "unknown",
@@ -228,12 +236,13 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
         ticketRootId: ticket.ticketRootId,
         version: ticket.version,
         ownerWallet: ticket.ownerWallet,
+        resalePrice: ticket.resalePrice ?? undefined,
       })),
     []
   );
 
   const refreshTickets = useCallback(async () => {
-    const ticketsData = await apiFetch<Array<{ id: string; purchasedAt?: string; quantity: number; seatIds?: string[]; ticketType?: { id: string; name: string; price: number; serviceFee: number }; event?: Partial<EventData>; isSecuredOnChain?: boolean; isForSale?: boolean; contractAddress?: string; ticketRootId?: number; version?: number; ownerWallet?: string }>>("/api/tickets");
+    const ticketsData = await apiFetch<Array<{ id: string; purchasedAt?: string; quantity: number; seatIds?: string[]; ticketType?: { id: string; name: string; price: number; serviceFee: number }; event?: Partial<EventData>; isSecuredOnChain?: boolean; isForSale?: boolean; contractAddress?: string; ticketRootId?: number; version?: number; ownerWallet?: string; resalePrice?: number | null }>>("/api/tickets");
     setPurchasedTickets(mapTicketsResponse(ticketsData));
   }, [apiFetch, mapTicketsResponse]);
 
@@ -241,7 +250,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     const data = await apiFetch<Array<{ id: string; soldAt: string; resalePrice: number; contractAddress?: string; ticketRootId?: number; version?: number; ticketType?: { id: string; name: string; price: number }; event?: Partial<EventData> }>>("/api/tickets/sold");
     setSoldTickets(data.map((t) => ({
       ...t,
-      event: t.event ? { ...t.event, image: (t.event as any)?.posterImage || (t.event as any)?.bannerImage || t.event?.image || "", bannerImage: (t.event as any)?.bannerImage || (t.event as any)?.posterImage || t.event?.bannerImage || "" } as EventData : undefined,
+      event: t.event ? normalizeEventData(t.event) : undefined,
     })));
   }, [apiFetch]);
 
@@ -254,14 +263,19 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       return;
     }
     void (async () => {
-      try {
-        const [cartData, ordersData, ticketsData, soldData] = await Promise.all([
-          apiFetch<Array<{ id: string; quantity: number; seatIds?: string[]; ticketType?: { id: string; name: string; price: number; serviceFee: number } }>>("/api/cart"),
-          apiFetch<Array<{ id: string; orderNumber?: string; createdAt: string; total: number; subtotal?: number; serviceFees?: number; status?: string }>>("/api/orders"),
-          apiFetch<Array<{ id: string; purchasedAt?: string; quantity: number; seatIds?: string[]; ticketType?: { id: string; name: string; price: number; serviceFee: number }; event?: Partial<EventData>; isSecuredOnChain?: boolean; isForSale?: boolean; contractAddress?: string; ticketRootId?: number; version?: number; ownerWallet?: string }>>("/api/tickets"),
-          apiFetch<Array<{ id: string; soldAt: string; resalePrice: number; contractAddress?: string; ticketRootId?: number; version?: number; ticketType?: { id: string; name: string; price: number }; event?: Partial<EventData> }>>("/api/tickets/sold"),
-        ]);
+      const load = async <T,>(label: string, request: () => Promise<T>): Promise<T | null> => {
+        try {
+          return await request();
+        } catch (error) {
+          console.error(`[APP] Error cargando ${label}:`, error);
+          return null;
+        }
+      };
 
+      const cartData = await load("carrito", () =>
+        apiFetch<Array<{ id: string; quantity: number; seatIds?: string[]; ticketType?: { id: string; name: string; price: number; serviceFee: number } }>>("/api/cart")
+      );
+      if (cartData) {
         setCart(
           cartData.map((item) => ({
             id: item.id,
@@ -275,10 +289,17 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
               available: 0,
               maxPerOrder: 10,
             },
-            event: (item as unknown as { event: EventData }).event,
+            event: normalizeEventData((item as unknown as { event?: Partial<EventData> }).event),
           }))
         );
+      } else {
+        setCart([]);
+      }
 
+      const ordersData = await load("órdenes", () =>
+        apiFetch<Array<{ id: string; orderNumber?: string; createdAt: string; total: number; subtotal?: number; serviceFees?: number; status?: string }>>("/api/orders")
+      );
+      if (ordersData) {
         setOrders(
           ordersData.map((order) => ({
             id: order.id,
@@ -295,17 +316,28 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
             status: order.status?.toLowerCase() === "pending" ? "pending" : "confirmed",
           }))
         );
+      } else {
+        setOrders([]);
+      }
 
+      const ticketsData = await load("tickets", () =>
+        apiFetch<Array<{ id: string; purchasedAt?: string; quantity: number; seatIds?: string[]; ticketType?: { id: string; name: string; price: number; serviceFee: number }; event?: Partial<EventData>; isSecuredOnChain?: boolean; isForSale?: boolean; contractAddress?: string; ticketRootId?: number; version?: number; ownerWallet?: string; resalePrice?: number | null }>>("/api/tickets")
+      );
+      if (ticketsData) {
         setPurchasedTickets(mapTicketsResponse(ticketsData));
+      } else {
+        setPurchasedTickets([]);
+      }
 
+      const soldData = await load("ventas", () =>
+        apiFetch<Array<{ id: string; soldAt: string; resalePrice: number; contractAddress?: string; ticketRootId?: number; version?: number; ticketType?: { id: string; name: string; price: number }; event?: Partial<EventData> }>>("/api/tickets/sold")
+      );
+      if (soldData) {
         setSoldTickets(soldData.map((t) => ({
           ...t,
-          event: t.event ? { ...t.event, image: (t.event as any)?.posterImage || (t.event as any)?.bannerImage || t.event?.image || "", bannerImage: (t.event as any)?.bannerImage || (t.event as any)?.posterImage || t.event?.bannerImage || "" } as EventData : undefined,
+          event: t.event ? normalizeEventData(t.event) : undefined,
         })));
-      } catch {
-        setCart([]);
-        setOrders([]);
-        setPurchasedTickets([]);
+      } else {
         setSoldTickets([]);
       }
     })();
@@ -540,12 +572,21 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     async (ticketId: string, priceXLM: number): Promise<{ success: boolean; txHash?: string; error?: string }> => {
       try {
         const priceStroops = Math.round(priceXLM * 10_000_000);
-        const result = await apiFetch<{ success: boolean; txHash: string }>("/api/transactions/list-ticket", {
+        const { xdr, networkPassphrase } = await apiFetch<{ xdr: string; networkPassphrase: string }>("/api/transactions/list-ticket", {
           method: "POST",
           body: JSON.stringify({ ticketId, price: priceStroops }),
         });
+        const { signTransaction } = await import("@stellar/freighter-api");
+        const signResult = await signTransaction(xdr, { networkPassphrase });
+        const signedXdr = typeof signResult === "string" ? signResult : (signResult as any)?.signedTxXdr ?? "";
+        if (!signedXdr) return { success: false, error: "Firma cancelada por el usuario" };
+
+        const result = await apiFetch<{ success: boolean; txHash: string }>("/api/transactions/submit", {
+          method: "POST",
+          body: JSON.stringify({ signedXdr }),
+        });
         setPurchasedTickets((prev) =>
-          prev.map((t) => (t.id === ticketId ? { ...t, isForSale: true } : t))
+          prev.map((t) => (t.id === ticketId ? { ...t, isForSale: true, resalePrice: priceStroops } : t))
         );
         return { success: true, txHash: result.txHash };
       } catch (error: any) {
@@ -558,12 +599,21 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   const cancelResaleListing = useCallback(
     async (ticketId: string): Promise<{ success: boolean; txHash?: string; error?: string }> => {
       try {
-        const result = await apiFetch<{ success: boolean; txHash: string }>("/api/transactions/cancel-listing", {
+        const { xdr, networkPassphrase } = await apiFetch<{ xdr: string; networkPassphrase: string }>("/api/transactions/cancel-listing", {
           method: "POST",
           body: JSON.stringify({ ticketId }),
         });
+        const { signTransaction } = await import("@stellar/freighter-api");
+        const signResult = await signTransaction(xdr, { networkPassphrase });
+        const signedXdr = typeof signResult === "string" ? signResult : (signResult as any)?.signedTxXdr ?? "";
+        if (!signedXdr) return { success: false, error: "Firma cancelada por el usuario" };
+
+        const result = await apiFetch<{ success: boolean; txHash: string }>("/api/transactions/submit", {
+          method: "POST",
+          body: JSON.stringify({ signedXdr }),
+        });
         setPurchasedTickets((prev) =>
-          prev.map((t) => (t.id === ticketId ? { ...t, isForSale: false } : t))
+          prev.map((t) => (t.id === ticketId ? { ...t, isForSale: false, resalePrice: undefined } : t))
         );
         return { success: true, txHash: result.txHash };
       } catch (error: any) {

--- a/frontend/src/data/events.ts
+++ b/frontend/src/data/events.ts
@@ -16,6 +16,7 @@ export interface EventData {
   category: string;
   city: string;
   venue: string;
+  venueType?: string;
   date: string;
   month: string;
   year: string;
@@ -112,6 +113,7 @@ const mapEvent = (item: EventListItemDto): EventData => {
     bannerImage: item.bannerImage || item.posterImage || "https://placehold.co/1200x400?text=Evento",
     featured: item.isFeatured ?? false,
     hasSeatSelection: item.hasSeatSelection ?? item.hasAssignedSeating ?? false,
+    venueType: (item as any).venueType ?? undefined,
     ticketTypes: [],
     relatedEventIds: [],
     price: price > 0 ? `Desde ${toCurrency(price)}` : "Gratis",

--- a/frontend/src/pages/Cart.tsx
+++ b/frontend/src/pages/Cart.tsx
@@ -4,6 +4,14 @@ import { Footer } from "@/components/layout/Footer";
 import { useAppContext } from "@/context/AppContext";
 import { Trash2, ShoppingCart, Minus, Plus } from "lucide-react";
 
+const getVenueName = (venue: unknown) => {
+  if (typeof venue === "string") return venue;
+  if (venue && typeof venue === "object" && "name" in venue) {
+    return String((venue as { name?: unknown }).name ?? "Venue por confirmar");
+  }
+  return "Venue por confirmar";
+};
+
 const Cart = () => {
   const { cart, removeFromCart, updateCartQuantity, clearCart } = useAppContext();
   const subtotal = cart.reduce((s, c) => s + c.ticketType.price * c.quantity, 0);
@@ -37,7 +45,7 @@ const Cart = () => {
                 <img src={item.event.image} alt={item.event.title} className="w-20 h-20 rounded-lg object-cover shrink-0" />
                 <div className="flex-1 min-w-0">
                   <p className="font-bold text-foreground text-sm truncate">{item.event.title}</p>
-                  <p className="text-xs text-muted-foreground">{item.event.date} {item.event.month} {item.event.year} · {item.event.venue}</p>
+                  <p className="text-xs text-muted-foreground">{item.event.date} {item.event.month} {item.event.year} · {getVenueName(item.event.venue)}</p>
                   <p className="text-xs text-primary font-bold mt-1">{item.ticketType.name}{item.seats?.length ? ` — ${item.seats.join(", ")}` : ""}</p>
                 </div>
                 <div className="flex flex-col items-end justify-between shrink-0">

--- a/frontend/src/pages/Checkout.tsx
+++ b/frontend/src/pages/Checkout.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate, Link } from "react-router-dom";
+import { Navigate, useNavigate, Link, useLocation } from "react-router-dom";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import { CheckoutStepper } from "@/components/ui/CheckoutStepper";
@@ -16,8 +16,9 @@ const Field = ({ label, name, type = "text", placeholder = "", value, onChange, 
 );
 
 const Checkout = () => {
-  const { cart, checkout } = useAppContext();
+  const { cart, checkout, isLoggedIn } = useAppContext();
   const navigate = useNavigate();
+  const location = useLocation();
   const [step, setStep] = useState(1);
   const [form, setForm] = useState({ name: "", email: "", phone: "", document: "", docType: "CC", payMethod: "card", terms: false });
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -25,6 +26,10 @@ const Checkout = () => {
   const subtotal = cart.reduce((s, c) => s + c.ticketType.price * c.quantity, 0);
   const fees = cart.reduce((s, c) => s + c.ticketType.serviceFee * c.quantity, 0);
   const total = subtotal + fees;
+
+  if (!isLoggedIn) {
+    return <Navigate to="/login" replace state={{ from: location.pathname, message: "Inicia sesión para finalizar la compra." }} />;
+  }
 
   if (cart.length === 0 && step < 3) return (
     <div className="min-h-screen bg-background flex flex-col"><Header />

--- a/frontend/src/pages/EventDetail.tsx
+++ b/frontend/src/pages/EventDetail.tsx
@@ -72,7 +72,7 @@ const EventDetail = () => {
   );
 
   const minPrice = event.ticketTypes.length ? Math.min(...event.ticketTypes.map((t) => t.price)) : 0;
-  const buyUrl = event.hasSeatSelection ? `/evento/${event.id}/asientos` : `/evento/${event.id}/boletas`;
+  const buyUrl = `/evento/${event.id}/asientos`;
 
   return (
     <div className="min-h-screen bg-background flex flex-col">

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,12 +1,19 @@
 import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import { useAppContext } from "@/context/AppContext";
 
+type LoginLocationState = {
+  from?: string;
+  message?: string;
+};
+
 const Login = () => {
   const { login } = useAppContext();
   const navigate = useNavigate();
+  const location = useLocation();
+  const locationState = location.state as LoginLocationState | null;
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -20,7 +27,7 @@ const Login = () => {
       setError("");
       setIsSubmitting(true);
       await login(email, password);
-      navigate("/mi-cuenta");
+      navigate(locationState?.from ?? "/mi-cuenta", { replace: true });
     } catch {
       setError("No fue posible iniciar sesión");
     } finally {
@@ -38,6 +45,7 @@ const Login = () => {
             <h1 className="text-2xl font-black text-foreground">Iniciar Sesión</h1>
             <p className="text-sm text-muted-foreground mt-1">Accede a tu cuenta TuTicket</p>
           </div>
+          {locationState?.message && <p className="text-sm text-primary font-semibold text-center bg-primary/10 rounded-lg px-3 py-2">{locationState.message}</p>}
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
               <label className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-1 block">Correo electrónico</label>

--- a/frontend/src/pages/SeatSelection.tsx
+++ b/frontend/src/pages/SeatSelection.tsx
@@ -2,10 +2,30 @@ import { useEffect, useState } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
-import { SeatMap, type SelectedSeat, type VenueType } from "@/components/ui/SeatMap";
+import { SeatMap, type SectionConfig, type SelectedSeat, type VenueType } from "@/components/ui/SeatMap";
 import { useAppContext } from "@/context/AppContext";
 import { ChevronLeft, ShoppingCart, Loader2 } from "lucide-react";
 import { getEventBySlug, getEventById, type EventData } from "@/data/events";
+
+interface SeatsApiResponse {
+  venueType: VenueType;
+  venueName: string;
+  sections: Array<{
+    id: string;
+    name: string;
+    ticketTypeId: string | null;
+    price: number;
+    serviceFee: number;
+    maxPerOrder: number;
+    seats: Array<{
+      seatId: string;
+      label: string;
+      row: string;
+      number: number;
+      status: "AVAILABLE" | "HELD" | "SOLD" | "BLOCKED";
+    }>;
+  }>;
+}
 
 const SeatSelection = () => {
   const { id } = useParams<{ id: string }>();
@@ -13,15 +33,17 @@ const SeatSelection = () => {
   const location = useLocation();
   const { addToCart, apiFetch, isLoggedIn } = useAppContext();
   const [event, setEvent] = useState<EventData | null>(null);
+  const [seatsResponse, setSeatsResponse] = useState<SeatsApiResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [selectedSeats, setSelectedSeats] = useState<SelectedSeat[]>([]);
   const [addingToCart, setAddingToCart] = useState(false);
-  const [occupancyPerSection, setOccupancyPerSection] = useState<Record<string, number>>({});
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!id) return;
     void (async () => {
       setLoading(true);
+      setError(null);
       try {
         let ev: EventData | null = null;
         try { ev = await getEventBySlug(id); } catch { /* fall through */ }
@@ -30,12 +52,10 @@ const SeatSelection = () => {
 
         if (ev) {
           try {
-            const occupancy = await apiFetch<Record<string, number>>(
-              `/api/events/${ev.id}/occupied-seats`
-            );
-            setOccupancyPerSection(occupancy);
-          } catch {
-            // non-fatal: map shows all seats available
+            const data = await apiFetch<SeatsApiResponse>(`/api/events/${ev.id}/seats`);
+            setSeatsResponse(data);
+          } catch (e: any) {
+            setError(e?.message || "No fue posible cargar los asientos");
           }
         }
       } catch {
@@ -71,28 +91,39 @@ const SeatSelection = () => {
     setAddingToCart(true);
     try {
       const grouped = selectedSeats.reduce<Record<string, SelectedSeat[]>>((acc, s) => {
-        (acc[s.sectionId] ??= []).push(s);
+        (acc[s.ticketTypeId] ??= []).push(s);
         return acc;
       }, {});
 
-      for (const [, seats] of Object.entries(grouped)) {
-        const first = seats[0];
-        const tt = event.ticketTypes.find((t) => t.id === first.ticketTypeId) ?? {
-          id: first.ticketTypeId,
-          name: first.sectionName,
-          price: first.price,
-          serviceFee: first.serviceFee,
-          available: 100,
-          maxPerOrder: 10,
-        };
-        await addToCart({
-          event,
-          ticketType: tt,
-          quantity: seats.length,
-          seats: seats.map((s) => s.id),
-        });
+      try {
+        for (const [, seats] of Object.entries(grouped)) {
+          const first = seats[0];
+          const tt = event.ticketTypes.find((t) => t.id === first.ticketTypeId) ?? {
+            id: first.ticketTypeId,
+            name: first.sectionName,
+            price: first.price,
+            serviceFee: first.serviceFee,
+            available: 100,
+            maxPerOrder: 10,
+          };
+          await addToCart({
+            event,
+            ticketType: tt,
+            quantity: seats.length,
+            seats: seats.map((s) => s.id),
+          });
+        }
+        navigate("/carrito");
+      } catch (e: any) {
+        // Seats may have been taken by another user between selection and add.
+        alert(e?.message ?? "No fue posible reservar los asientos. Recarga la página y vuelve a intentar.");
+        // Refresh seat availability
+        try {
+          const data = await apiFetch<SeatsApiResponse>(`/api/events/${event.id}/seats`);
+          setSeatsResponse(data);
+          setSelectedSeats([]);
+        } catch { /* ignore */ }
       }
-      navigate("/carrito");
     } finally {
       setAddingToCart(false);
     }
@@ -123,14 +154,20 @@ const SeatSelection = () => {
     );
   }
 
-  const sections = event.ticketTypes.map((tt) => ({
-    id: tt.id,
-    name: tt.name,
-    price: tt.price,
-    serviceFee: tt.serviceFee,
-    capacity: tt.available > 0 ? tt.available : Math.max(tt.maxPerOrder * 10, 80),
-    maxPerOrder: tt.maxPerOrder,
-  }));
+  const sections: SectionConfig[] = (seatsResponse?.sections ?? [])
+    .filter((s) => s.ticketTypeId !== null)
+    .map((s) => ({
+      id: s.id,
+      name: s.name,
+      ticketTypeId: s.ticketTypeId as string,
+      price: s.price,
+      serviceFee: s.serviceFee,
+      maxPerOrder: s.maxPerOrder,
+      seats: s.seats,
+    }));
+
+  const venueType: VenueType = seatsResponse?.venueType ?? (event.venueType as VenueType) ?? "ARENA";
+  const venueName = seatsResponse?.venueName ?? event.venue;
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
@@ -148,15 +185,18 @@ const SeatSelection = () => {
         <div className="grid lg:grid-cols-3 gap-8">
           <div className="lg:col-span-2 bg-card rounded-xl border border-border p-6 overflow-x-auto">
             <h2 className="font-black text-foreground uppercase tracking-tight mb-6">Selecciona tus Asientos</h2>
-            <SeatMap
-              venueType={(event.venueType as VenueType) ?? "ARENA"}
-              venueName={event.venue}
-              sections={sections}
-              selectedSeats={selectedSeats}
-              onToggleSeat={toggleSeat}
-              maxSeats={10}
-              occupancyPerSection={occupancyPerSection}
-            />
+            {error ? (
+              <p className="text-sm text-destructive py-8 text-center">{error}</p>
+            ) : (
+              <SeatMap
+                venueType={venueType}
+                venueName={venueName}
+                sections={sections}
+                selectedSeats={selectedSeats}
+                onToggleSeat={toggleSeat}
+                maxSeats={10}
+              />
+            )}
           </div>
 
           <div>

--- a/frontend/src/pages/SeatSelection.tsx
+++ b/frontend/src/pages/SeatSelection.tsx
@@ -2,94 +2,203 @@ import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
-import { getEventById, getEventTicketTypes, type EventData } from "@/data/events";
-import { SeatMap, type Seat } from "@/components/ui/SeatMap";
+import { SeatMap, type SelectedSeat, type VenueType } from "@/components/ui/SeatMap";
 import { useAppContext } from "@/context/AppContext";
-import { ChevronLeft, ShoppingCart } from "lucide-react";
+import { ChevronLeft, ShoppingCart, Loader2 } from "lucide-react";
+import { getEventBySlug, getEventById, type EventData } from "@/data/events";
 
 const SeatSelection = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { addToCart } = useAppContext();
+  const { addToCart, apiFetch } = useAppContext();
+
   const [event, setEvent] = useState<EventData | null>(null);
   const [loading, setLoading] = useState(true);
-  const [selectedSeats, setSelectedSeats] = useState<Seat[]>([]);
+  const [selectedSeats, setSelectedSeats] = useState<SelectedSeat[]>([]);
+  const [addingToCart, setAddingToCart] = useState(false);
+  const [occupancyPerSection, setOccupancyPerSection] = useState<Record<string, number>>({});
 
   useEffect(() => {
     if (!id) return;
     void (async () => {
       setLoading(true);
       try {
-        const eventById = await getEventById(id);
-        if (!eventById) {
-          setEvent(null);
-          return;
+        let ev: EventData | null = null;
+        try { ev = await getEventBySlug(id); } catch { /* fall through */ }
+        if (!ev) ev = await getEventById(id);
+        setEvent(ev);
+
+        if (ev) {
+          try {
+            const occupancy = await apiFetch<Record<string, number>>(
+              `/api/events/${ev.id}/occupied-seats`
+            );
+            setOccupancyPerSection(occupancy);
+          } catch {
+            // non-fatal: map shows all seats available
+          }
         }
-        const ticketTypes = await getEventTicketTypes(eventById.id);
-        setEvent({ ...eventById, ticketTypes });
       } catch {
         setEvent(null);
       } finally {
         setLoading(false);
       }
     })();
-  }, [id]);
+  }, [id, apiFetch]);
 
-  if (loading) return <div className="min-h-screen bg-background flex flex-col"><Header /><div className="flex-1 flex items-center justify-center"><p className="text-foreground font-bold">Cargando evento...</p></div><Footer /></div>;
-  if (!event) return <div className="min-h-screen bg-background flex flex-col"><Header /><div className="flex-1 flex items-center justify-center"><p className="text-foreground font-bold">Evento no encontrado</p></div><Footer /></div>;
-
-  const toggleSeat = (seat: Seat) => {
-    setSelectedSeats((prev) =>
-      prev.some((s) => s.id === seat.id) ? prev.filter((s) => s.id !== seat.id) : prev.length < 10 ? [...prev, seat] : prev
-    );
+  const toggleSeat = (seat: SelectedSeat) => {
+    setSelectedSeats((prev) => {
+      const exists = prev.some((s) => s.id === seat.id);
+      if (exists) return prev.filter((s) => s.id !== seat.id);
+      if (prev.length >= 10) return prev;
+      return [...prev, seat];
+    });
   };
 
   const total = selectedSeats.reduce((s, seat) => s + seat.price + seat.serviceFee, 0);
 
   const handleAdd = async () => {
-    if (selectedSeats.length === 0) return;
-    const grouped = selectedSeats.reduce<Record<string, Seat[]>>((acc, s) => {
-      (acc[s.section] ??= []).push(s);
-      return acc;
-    }, {});
-    await Promise.all(Object.entries(grouped).map(async ([section, seats]) => {
-      const tt = event.ticketTypes.find((t) => t.name === section) ?? { id: section.toLowerCase(), name: section, price: seats[0].price, serviceFee: seats[0].serviceFee, available: 100, maxPerOrder: 10 };
-      await addToCart({ event, ticketType: tt, quantity: seats.length, seats: seats.map((s) => s.id) });
-    }));
-    navigate("/carrito");
+    if (selectedSeats.length === 0 || !event) return;
+    setAddingToCart(true);
+    try {
+      const grouped = selectedSeats.reduce<Record<string, SelectedSeat[]>>((acc, s) => {
+        (acc[s.sectionId] ??= []).push(s);
+        return acc;
+      }, {});
+
+      for (const [, seats] of Object.entries(grouped)) {
+        const first = seats[0];
+        const tt = event.ticketTypes.find((t) => t.id === first.ticketTypeId) ?? {
+          id: first.ticketTypeId,
+          name: first.sectionName,
+          price: first.price,
+          serviceFee: first.serviceFee,
+          available: 100,
+          maxPerOrder: 10,
+        };
+        await addToCart({
+          event,
+          ticketType: tt,
+          quantity: seats.length,
+          seats: seats.map((s) => s.id),
+        });
+      }
+      navigate("/carrito");
+    } finally {
+      setAddingToCart(false);
+    }
   };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-background flex flex-col">
+        <Header />
+        <div className="flex-1 flex items-center justify-center gap-2 text-muted-foreground">
+          <Loader2 className="w-5 h-5 animate-spin" />
+          <span className="text-sm">Cargando evento...</span>
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+
+  if (!event) {
+    return (
+      <div className="min-h-screen bg-background flex flex-col">
+        <Header />
+        <div className="flex-1 flex items-center justify-center">
+          <p className="text-foreground font-bold">Evento no encontrado</p>
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+
+  const sections = event.ticketTypes.map((tt) => ({
+    id: tt.id,
+    name: tt.name,
+    price: tt.price,
+    serviceFee: tt.serviceFee,
+    capacity: tt.available > 0 ? tt.available : Math.max(tt.maxPerOrder * 10, 80),
+    maxPerOrder: tt.maxPerOrder,
+  }));
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
       <Header />
       <main className="flex-1 max-w-6xl mx-auto px-4 py-8 w-full">
-        <button onClick={() => navigate(-1)} className="flex items-center gap-1 text-sm text-primary font-bold mb-6 hover:underline"><ChevronLeft className="w-4 h-4" /> Volver</button>
-        <h1 className="text-2xl font-black text-foreground uppercase tracking-tight mb-2">{event.title}</h1>
-        <p className="text-sm text-muted-foreground mb-6">{event.date} {event.month} {event.year} · {event.venue}, {event.city}</p>
+        <button onClick={() => navigate(-1)} className="flex items-center gap-1 text-sm text-primary font-bold mb-6 hover:underline">
+          <ChevronLeft className="w-4 h-4" /> Volver
+        </button>
+
+        <h1 className="text-2xl font-black text-foreground uppercase tracking-tight mb-1">{event.title}</h1>
+        <p className="text-sm text-muted-foreground mb-8">
+          {event.date} {event.month} {event.year} · {event.venue}, {event.city}
+        </p>
+
         <div className="grid lg:grid-cols-3 gap-8">
           <div className="lg:col-span-2 bg-card rounded-xl border border-border p-6 overflow-x-auto">
-            <h2 className="font-black text-foreground uppercase tracking-tight mb-4">Selecciona tus Asientos</h2>
-            <SeatMap eventId={event.id} selectedSeats={selectedSeats} onToggleSeat={toggleSeat} />
+            <h2 className="font-black text-foreground uppercase tracking-tight mb-6">Selecciona tus Asientos</h2>
+            <SeatMap
+              venueType={(event.venueType as VenueType) ?? "ARENA"}
+              venueName={event.venue}
+              sections={sections}
+              selectedSeats={selectedSeats}
+              onToggleSeat={toggleSeat}
+              maxSeats={10}
+              occupancyPerSection={occupancyPerSection}
+            />
           </div>
+
           <div>
             <div className="sticky top-24 bg-card rounded-xl border border-border p-6 space-y-4">
               <h3 className="font-black text-foreground uppercase tracking-tight">Resumen</h3>
-              {selectedSeats.length > 0 ? (
+
+              {selectedSeats.length === 0 ? (
+                <div className="text-center py-6 space-y-2">
+                  <p className="text-sm text-muted-foreground">Selecciona una sección en el mapa y luego haz clic en los asientos.</p>
+                  <p className="text-xs text-muted-foreground">(Máx. 10 asientos)</p>
+                </div>
+              ) : (
                 <>
-                  <div className="space-y-2 max-h-48 overflow-y-auto">
+                  <div className="space-y-2 max-h-64 overflow-y-auto pr-1">
                     {selectedSeats.map((s) => (
-                      <div key={s.id} className="flex justify-between text-sm">
-                        <span className="text-muted-foreground">{s.id}</span>
-                        <span className="font-bold text-foreground">${s.price.toLocaleString("es-CO")}</span>
+                      <div key={s.id} className="flex justify-between items-start text-sm gap-2">
+                        <div>
+                          <span className="font-bold text-foreground block leading-tight">{s.label}</span>
+                          <span className="text-[11px] text-muted-foreground">+${s.serviceFee.toLocaleString("es-CO")} serv.</span>
+                        </div>
+                        <span className="font-black text-foreground whitespace-nowrap">${s.price.toLocaleString("es-CO")}</span>
                       </div>
                     ))}
                   </div>
+
                   <hr className="border-border" />
-                  <div className="flex justify-between font-black text-foreground"><span>Total ({selectedSeats.length})</span><span>${total.toLocaleString("es-CO")}</span></div>
-                  <button onClick={handleAdd} className="w-full py-3 bg-accent hover:bg-accent/90 text-accent-foreground font-black rounded-lg flex items-center justify-center gap-2 transition-colors text-sm"><ShoppingCart className="w-4 h-4" /> Agregar al Carrito</button>
+
+                  <div className="space-y-1 text-sm">
+                    <div className="flex justify-between text-muted-foreground">
+                      <span>Subtotal ({selectedSeats.length})</span>
+                      <span>${selectedSeats.reduce((a, s) => a + s.price, 0).toLocaleString("es-CO")}</span>
+                    </div>
+                    <div className="flex justify-between text-muted-foreground">
+                      <span>Servicio</span>
+                      <span>${selectedSeats.reduce((a, s) => a + s.serviceFee, 0).toLocaleString("es-CO")}</span>
+                    </div>
+                    <div className="flex justify-between font-black text-foreground text-base pt-1">
+                      <span>Total</span>
+                      <span>${total.toLocaleString("es-CO")}</span>
+                    </div>
+                  </div>
+
+                  <button
+                    onClick={handleAdd}
+                    disabled={addingToCart}
+                    className="w-full py-3 bg-accent hover:bg-accent/90 disabled:opacity-60 text-accent-foreground font-black rounded-lg flex items-center justify-center gap-2 transition-colors text-sm"
+                  >
+                    {addingToCart ? <Loader2 className="w-4 h-4 animate-spin" /> : <ShoppingCart className="w-4 h-4" />}
+                    {addingToCart ? "Agregando..." : "Agregar al Carrito"}
+                  </button>
                 </>
-              ) : (
-                <p className="text-sm text-muted-foreground text-center py-4">Selecciona asientos en el mapa<br/><span className="text-xs">(Máx. 10 asientos)</span></p>
               )}
             </div>
           </div>

--- a/frontend/src/pages/SeatSelection.tsx
+++ b/frontend/src/pages/SeatSelection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import { getEventById, getEventTicketTypes, type EventData } from "@/data/events";
@@ -10,7 +10,8 @@ import { ChevronLeft, ShoppingCart } from "lucide-react";
 const SeatSelection = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { addToCart } = useAppContext();
+  const location = useLocation();
+  const { addToCart, isLoggedIn } = useAppContext();
   const [event, setEvent] = useState<EventData | null>(null);
   const [loading, setLoading] = useState(true);
   const [selectedSeats, setSelectedSeats] = useState<Seat[]>([]);
@@ -48,6 +49,15 @@ const SeatSelection = () => {
 
   const handleAdd = async () => {
     if (selectedSeats.length === 0) return;
+    if (!isLoggedIn) {
+      navigate("/login", {
+        state: {
+          from: location.pathname,
+          message: "Inicia sesión para agregar asientos al carrito.",
+        },
+      });
+      return;
+    }
     const grouped = selectedSeats.reduce<Record<string, Seat[]>>((acc, s) => {
       (acc[s.section] ??= []).push(s);
       return acc;

--- a/frontend/src/pages/TicketPurchase.tsx
+++ b/frontend/src/pages/TicketPurchase.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import { getEventById, getEventTicketTypes, type EventData } from "@/data/events";
@@ -10,7 +10,8 @@ import { ChevronLeft, ShoppingCart } from "lucide-react";
 const TicketPurchase = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { addToCart } = useAppContext();
+  const location = useLocation();
+  const { addToCart, isLoggedIn } = useAppContext();
   const [event, setEvent] = useState<EventData | null>(null);
   const [loading, setLoading] = useState(true);
   const [selected, setSelected] = useState<Record<string, number>>({});
@@ -56,6 +57,15 @@ const TicketPurchase = () => {
   }, 0);
 
   const handleAdd = async () => {
+    if (!isLoggedIn) {
+      navigate("/login", {
+        state: {
+          from: location.pathname,
+          message: "Inicia sesión para agregar boletos al carrito.",
+        },
+      });
+      return;
+    }
     await Promise.all(Object.entries(selected).map(async ([tid, qty]) => {
       const tt = event.ticketTypes.find((t) => t.id === tid);
       if (tt && qty > 0) await addToCart({ event, ticketType: tt, quantity: qty });


### PR DESCRIPTION
## Qué se hizo                                                           
  - Restaurado el flujo de compra por asientos: todos los eventos ahora tienen inventario de asientos (3 secciones por venue: VIP, Platea, General) con script `seed-seat-inventory.ts` idempotente
  - Corregido el trigger de DB `validate_cart_item_consistency` que rechazaba inserts de items seat-based                                                                                                                    
  - Restaurada la función `set_updated_at` que fue sobreescrita accidentalmente con lógica del cart trigger (causaba `column "new" does not exist` en cualquier UPDATE)
  - Corregidos los DTOs de `GET /api/cart`, `GET /api/tickets`, `POST /api/transactions/secure-ticket` y `GET /api/tickets/sold` para resolver ticketType y event vía `event_seat_inventory.event_ticket_types` cuando el    
  item no tiene `event_ticket_type_id` directo              
  - Rotadas las wallets del proyecto (ADMIN, ORGANIZER, PLATFORM, BUYER1, BUYER2, VERIFIER) a un set con nombres claros para trazabilidad de la tesis
  - Recompilado `event_contract.wasm` con target `wasm32v1-none` (el WASM previo era del 31-mar y no tenía `crear_boleto_para`). Redesplegados 12 contratos en testnet con las nuevas wallets
  - Refactorizado `deploy-contracts.ts`: carga keys desde `.env.deploy`, usa salt aleatorio, apunta a `contracts/wasm/`
  - UI de reventa: reemplazado `prompt()` nativo por Dialog de shadcn/ui. El usuario ingresa el precio en COP y ve el equivalente en XLM en tiempo real
  - `ConnectWallet` ahora lee `walletAddress` del AppContext en vez de estado local, manteniendo la wallet visible al cambiar de páginas

  ## Por qué
  - El flujo de asientos dejó de funcionar después de un refactor previo que asumía `has_assigned_seating = true` y datos de inventario ya existentes en la DB
  - Los triggers de DB tenían lógica incompatible con el flujo seat-based introducido por ese refactor
  - Las wallets anteriores eran keypairs aleatorios sin nombre, dificultando la trazabilidad en la tesis
  - El WASM desactualizado impedía registrar boletos on-chain (`crear_boleto_para` no existía)
  - El `prompt()` del navegador es visualmente inconsistente con el resto de la UI y no permite mostrar información adicional (conversión COP→XLM en tiempo real)
  - Cada página renderiza su propio `<Header />`, lo que desmontaba `ConnectWallet` al navegar y borraba el estado de la wallet

  ## Cómo se probó
  - Flujo completo: selección de asiento → agregar al carrito → checkout → ver en Mis Entradas → Asegurar en Blockchain → Revender NFT (con Dialog COP) → verificar wallet persiste al navegar entre páginas
  - `set_updated_at` restaurada y verificada: updates en `event_seat_inventory` funcionan sin error
  - 12 contratos redesplegados y confirmados en Stellar Expert testnet con las nuevas wallets

  ## Riesgos
  - Los tickets previamente "Asegurados en Blockchain" apuntan a los contratos anteriores (rotados). Para el demo es aceptable; en producción requeriría migración
  - El precio de reventa en XLM depende de la cotización de CoinGecko en el momento de listar; si la cotización varía, el valor on-chain puede diferir del esperado en COP
  - `.env.deploy` contiene private keys de testnet — no subido al repo (verificado en el checklist)

  ## Checklist
  - [x] compiló correctamente
  - [x] probé el flujo afectado
  - [x] no subí secretos ni archivos temporales (`.env`, `.env.deploy`, `.claude/` excluidos)
  - [x] actualicé documentación si aplicaba (CLAUDE.md con sección Phase 4.1)