### PR TITLE
fix ticket redemption through soroban

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,3 +9,7 @@ JWT_SECRET="change-this-to-a-random-secret-in-production"
 # Opcional: operaciones on-chain desde el backend (ver backend/README.md)
 # ORGANIZER_SECRET=
 # ORGANIZER_PUBLIC=
+# Recomendado: wallet operativa autorizada como verificador en cada contrato.
+# Si falta, el backend usa ORGANIZER_SECRET como fallback solo para demo.
+# VERIFIER_SECRET=
+# VERIFIER_PUBLIC=

--- a/backend/README.md
+++ b/backend/README.md
@@ -89,11 +89,15 @@ Si la indexación continua se ejecuta por separado en tu despliegue, debe apunta
 | `SOROBAN_RPC_URL`   | No         | RPC Soroban (por defecto testnet público). |
 | `ORGANIZER_SECRET`  | No**       | Secret key del organizador para operaciones que construyen/envían transacciones desde el backend. |
 | `ORGANIZER_PUBLIC`  | No         | Clave pública del organizador usada en rutas admin/contratos si no quieres el valor por defecto del código. |
+| `VERIFIER_SECRET`   | No***      | Secret key de la wallet verificador autorizada en contratos de evento para ejecutar redenciones on-chain. |
+| `VERIFIER_PUBLIC`   | No         | Clave pública del verificador usada como referencia operativa. |
 | `VERCEL`            | No         | En despliegues serverless la define el proveedor; si existe, `server.ts` no ejecuta el bloque de proceso largo (`listen` + `runIndexer()`). |
 
 \* En desarrollo local, si `JWT_SECRET` no está definido, el servidor permite un fallback inseguro y muestra un warning en consola. Ese fallback no debe usarse en entornos compartidos, demos públicas ni producción; con `NODE_ENV=production`, la aplicación falla al iniciar si falta `JWT_SECRET`.
 
 \*\* Sin `ORGANIZER_SECRET`, algunas rutas on-chain responderán con error de servicio no configurado.
+
+\*\*\* Si `VERIFIER_SECRET` no está definido, el backend usa `ORGANIZER_SECRET` como fallback para demo. Para un entorno production-like, usa una wallet separada y registrada con `agregar_verificador` en cada contrato.
 
 Copia `.env.example` a `.env` y ajusta valores; las claves de organizador suelen ser solo locales o secretos del proveedor, nunca en el repositorio.
 

--- a/backend/scripts/deploy-contracts.ts
+++ b/backend/scripts/deploy-contracts.ts
@@ -174,6 +174,31 @@ async function initializeEventContract(
   console.log(`  Initialized!`);
 }
 
+async function addVerifier(
+  organizerKeypair: Keypair,
+  contractAddress: string,
+  verifierPubKey: string,
+): Promise<void> {
+  console.log(`  Adding verifier ${verifierPubKey.slice(0, 8)}...`);
+  const account = await getAccount(organizerKeypair.publicKey());
+
+  const tx = new TransactionBuilder(account, {
+    fee: '10000000',
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(Operation.invokeContractFunction({
+      contract: contractAddress,
+      function: 'agregar_verificador',
+      args: [
+        new Address(verifierPubKey).toScVal(),
+      ],
+    }))
+    .setTimeout(60);
+
+  await submitTx(tx, organizerKeypair);
+  console.log(`  Verifier added!`);
+}
+
 async function main() {
   console.log('=== Soroban Contract Deployment to Testnet ===\n');
 
@@ -181,11 +206,13 @@ async function main() {
   const adminKeypair = Keypair.random();
   const platformKeypair = Keypair.random();
   const organizerKeypair = process.env.ORGANIZER_SECRET ? Keypair.fromSecret(process.env.ORGANIZER_SECRET) : Keypair.random();
+  const verifierKeypair = process.env.VERIFIER_SECRET ? Keypair.fromSecret(process.env.VERIFIER_SECRET) : organizerKeypair;
 
   console.log('Keypairs:');
   console.log(`  Admin:     ${adminKeypair.publicKey()}`);
   console.log(`  Platform:  ${platformKeypair.publicKey()}`);
   console.log(`  Organizer: ${organizerKeypair.publicKey()}`);
+  console.log(`  Verifier:  ${verifierKeypair.publicKey()}`);
 
   // Save keypairs to .env.deploy for reference
   const envDeploy = `# Generated ${new Date().toISOString()}
@@ -195,6 +222,8 @@ PLATFORM_PUBLIC=${platformKeypair.publicKey()}
 PLATFORM_SECRET=${platformKeypair.secret()}
 ORGANIZER_PUBLIC=${organizerKeypair.publicKey()}
 ORGANIZER_SECRET=${organizerKeypair.secret()}
+VERIFIER_PUBLIC=${verifierKeypair.publicKey()}
+VERIFIER_SECRET=${verifierKeypair.secret()}
 `;
   fs.writeFileSync(path.resolve(__dirname, '../.env.deploy'), envDeploy);
   console.log('\n  Keypairs saved to .env.deploy');
@@ -204,6 +233,7 @@ ORGANIZER_SECRET=${organizerKeypair.secret()}
   await fundAccount(adminKeypair.publicKey());
   await fundAccount(platformKeypair.publicKey());
   await fundAccount(organizerKeypair.publicKey());
+  await fundAccount(verifierKeypair.publicKey());
 
   // 3. Upload event_contract WASM
   const eventWasmPath = path.join(WASM_DIR, 'event_contract.optimized.wasm');
@@ -239,6 +269,7 @@ ORGANIZER_SECRET=${organizerKeypair.secret()}
         contractAddress,
         platformKeypair.publicKey(),
       );
+      await addVerifier(organizerKeypair, contractAddress, verifierKeypair.publicKey());
 
       // Update DB
       await prisma.events.update({

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -53,6 +53,8 @@ const sorobanServer = new SorobanRpc.Server(SOROBAN_RPC_URL);
 // Organizer keypair for on-chain operations (from deploy)
 const ORGANIZER_SECRET = process.env.ORGANIZER_SECRET;
 const organizerKeypair = ORGANIZER_SECRET ? Keypair.fromSecret(ORGANIZER_SECRET) : null;
+const VERIFIER_SECRET = process.env.VERIFIER_SECRET;
+const verifierKeypair = VERIFIER_SECRET ? Keypair.fromSecret(VERIFIER_SECRET) : organizerKeypair;
 
 // Helper: build user DTO for frontend
 function toUserDto(user: { id: string; first_name: string; last_name: string; email: string; phone: string | null; document_type: string; document_number: string; wallet_address?: string | null; role?: string }) {
@@ -748,7 +750,7 @@ app.get('/api/admin/venues', authMiddleware, async (req, res) => {
   } catch (error: any) { res.status(500).json({ error: error.message }); }
 });
 
-// POST /api/admin/scan — Redeem a ticket
+// POST /api/admin/scan — Redeem a ticket on Soroban, then project the result to PostgreSQL
 app.post('/api/admin/scan', authMiddleware, async (req, res) => {
   try {
     const user = await prisma.users.findUnique({ where: { id: (req as any).userId } });
@@ -756,28 +758,87 @@ app.post('/api/admin/scan', authMiddleware, async (req, res) => {
 
     const { ticketId } = req.body;
     if (!ticketId) { res.status(400).json({ error: 'ticketId es requerido' }); return; }
+    if (!verifierKeypair) {
+      res.status(503).json({ error: 'Blockchain no configurada (falta VERIFIER_SECRET u ORGANIZER_SECRET)' });
+      return;
+    }
 
     // Check if the ticket exists
     const ticket = await prisma.tickets.findUnique({ where: { id: ticketId } });
-    
     if (!ticket) {
       res.status(404).json({ error: 'Boleto no encontrado en la base de datos' });
       return;
     }
 
-    if (ticket.status !== 'ACTIVE') {
-      res.status(400).json({ error: `Boleto inhabilitado: ${ticket.status}` });
+    if (!ticket.contract_address || ticket.ticket_root_id === null) {
+      res.status(409).json({ error: 'Boleto no asegurado en blockchain; no se puede redimir solo con PostgreSQL' });
       return;
     }
 
-    // In a real Web3 environment, if ticket.contract_address exists, we'd trigger a Soroban burn here via CLI
-    // For this simulation/hybrid speed, we update Postgres linearly to avoid gate delays.
+    console.log(`[SOROBAN] Redeeming ticket root_id=${ticket.ticket_root_id} with verifier=${verifierKeypair.publicKey().slice(0, 8)}...`);
+
+    const accountResponse = await sorobanServer.getAccount(verifierKeypair.publicKey());
+    const account = new Account(accountResponse.accountId(), accountResponse.sequenceNumber());
+
+    const tx = new TransactionBuilder(account, {
+      fee: '10000000',
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(Operation.invokeContractFunction({
+        contract: ticket.contract_address,
+        function: 'redimir_boleto',
+        args: [
+          nativeToScVal(ticket.ticket_root_id, { type: 'u32' }),
+          new Address(verifierKeypair.publicKey()).toScVal(),
+        ],
+      }))
+      .setTimeout(60)
+      .build();
+
+    const simResponse = await sorobanServer.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationError(simResponse)) {
+      const simError = (simResponse as any).error || 'desconocido';
+      console.error('[SOROBAN] Redeem simulation failed:', simError);
+      res.status(400).json({ error: 'Redención rechazada por Soroban: ' + simError });
+      return;
+    }
+
+    const assembled = SorobanRpc.assembleTransaction(tx, simResponse).build();
+    assembled.sign(verifierKeypair);
+
+    const sendResponse = await sorobanServer.sendTransaction(assembled);
+    if (sendResponse.status === 'ERROR') {
+      console.error('[SOROBAN] Redeem send failed:', sendResponse);
+      res.status(400).json({ error: 'La red rechazó la redención firmada' });
+      return;
+    }
+
+    let getResponse: SorobanRpc.Api.GetTransactionResponse;
+    let attempts = 0;
+    do {
+      await new Promise((r) => setTimeout(r, 2000));
+      getResponse = await sorobanServer.getTransaction(sendResponse.hash);
+      attempts++;
+    } while (getResponse.status === 'NOT_FOUND' && attempts < 30);
+
+    if (getResponse.status !== 'SUCCESS') {
+      res.status(400).json({ error: 'Redención blockchain fallida: ' + getResponse.status });
+      return;
+    }
+
+    // PostgreSQL is only the off-chain projection after Soroban confirms the critical state change.
     await prisma.tickets.update({
        where: { id: ticket.id },
-       data: { status: 'CANCELLED' } // 'CANCELLED' is the generic inactive state in Prisma schema for this thesis demo
+       data: { status: 'USED', used_at: new Date(), is_for_sale: false }
     });
 
-    res.json({ success: true, message: 'Boleto redimido exitosamente' });
+    res.json({
+      success: true,
+      message: 'Boleto redimido exitosamente en Soroban',
+      txHash: sendResponse.hash,
+      contractAddress: ticket.contract_address,
+      ticketRootId: ticket.ticket_root_id,
+    });
   } catch (error: any) {
     console.error('[SCAN] Error:', error);
     res.status(500).json({ error: error.message });

--- a/frontend/src/pages/Scanner.tsx
+++ b/frontend/src/pages/Scanner.tsx
@@ -105,7 +105,7 @@ export const ScannerPage = () => {
         <div className="mt-8 bg-accent/10 p-4 rounded-xl flex items-start gap-3 w-full border border-accent/20">
           <ShieldCheck className="w-5 h-5 text-accent shrink-0 mt-0.5" />
           <p className="text-xs text-muted-foreground">
-            Los escaneos verifican la base de datos híbrida de Stellar Tickets de forma instantánea. Las validaciones asíncronas en cadena (Soroban) se ejecutarán en segundo plano.
+            Los escaneos redimen el boleto en Soroban y luego sincronizan PostgreSQL como proyección off-chain.
           </p>
         </div>
       </main>


### PR DESCRIPTION
## Qué se hizo
- La redención de tickets ahora llama `redimir_boleto` en Soroban antes de actualizar PostgreSQL.
- PostgreSQL queda como proyección off-chain después de la confirmación on-chain.
- Se agregó soporte para `VERIFIER_SECRET` / `VERIFIER_PUBLIC`.
- El script de deploy registra un verificador en contratos nuevos.
- Se actualizó el texto del scanner para reflejar el flujo real.

## Por qué
- La blockchain debe ser la fuente de verdad para el estado crítico del ticket.
- Antes el scanner podía marcar tickets como redimidos solo en PostgreSQL.
- Esto podía generar inconsistencia entre DB y Soroban.

## Cómo se probó
- `cd backend && npx tsc --noEmit`
- `cd frontend && npm run build`
- `cd contracts && cargo test -p event_contract`
- `git diff --check`

## Riesgos
- Los contratos viejos sin verificador registrado rechazarán redenciones, lo cual es esperado.
- En demo, si falta `VERIFIER_SECRET`, se usa `ORGANIZER_SECRET` como fallback.
- Falta prueba E2E real con ticket asegurado en testnet y verificador registrado.

## Checklist
- [x] compiló correctamente
- [x] probé el flujo afectado a nivel código/contrato
- [x] no subí secretos ni archivos temporales
- [x] actualicé documentación si aplicaba